### PR TITLE
ci: add GitHub Actions for frontend, Clarity, EVM, PR-title, and deps

### DIFF
--- a/.github/workflows/clarity.yml
+++ b/.github/workflows/clarity.yml
@@ -30,3 +30,22 @@ jobs:
 
       - run: npm ci
       - run: npm test
+
+  clarinet-check:
+    name: Clarinet check
+    runs-on: ubuntu-latest
+    env:
+      CLARINET_VERSION: '2.11.2'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clarinet
+        run: |
+          curl -L -o clarinet.tar.gz \
+            "https://github.com/hirosystems/clarinet/releases/download/v${CLARINET_VERSION}/clarinet-linux-x64-glibc.tar.gz"
+          tar -xzf clarinet.tar.gz
+          sudo mv clarinet /usr/local/bin/clarinet
+          clarinet --version
+        working-directory: .
+
+      - run: clarinet check

--- a/.github/workflows/clarity.yml
+++ b/.github/workflows/clarity.yml
@@ -1,0 +1,32 @@
+name: Clarity
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'smartcontracts/**'
+      - '.github/workflows/clarity.yml'
+  pull_request:
+    paths:
+      - 'smartcontracts/**'
+      - '.github/workflows/clarity.yml'
+
+defaults:
+  run:
+    working-directory: smartcontracts
+
+jobs:
+  vitest:
+    name: Vitest (clarinet-sdk)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: smartcontracts/package-lock.json
+
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          # Reject GPL-family licenses; allow common permissive ones.
+          allow-licenses: >-
+            MIT,
+            Apache-2.0,
+            BSD-2-Clause,
+            BSD-3-Clause,
+            ISC,
+            CC0-1.0,
+            0BSD,
+            Unlicense

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -1,0 +1,34 @@
+name: EVM
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'smartcontracts-evm/**'
+      - 'contributions/**'
+      - '.github/workflows/evm.yml'
+  pull_request:
+    paths:
+      - 'smartcontracts-evm/**'
+      - 'contributions/**'
+      - '.github/workflows/evm.yml'
+
+defaults:
+  run:
+    working-directory: smartcontracts-evm
+
+jobs:
+  compile:
+    name: Hardhat compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: smartcontracts-evm/package-lock.json
+
+      - run: npm ci
+      - run: npm run compile

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -32,3 +32,33 @@ jobs:
 
       - run: npm ci
       - run: npm run compile
+
+  test:
+    name: Hardhat test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: smartcontracts-evm/package-lock.json
+
+      - run: npm ci
+      - run: npm test
+
+  solhint:
+    name: Solhint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: smartcontracts-evm/package-lock.json
+
+      - run: npm ci
+      - run: npm run lint

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -45,3 +45,20 @@ jobs:
 
       - run: npm ci
       - run: npx tsc --noEmit
+
+  build:
+    name: Build (next build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+      - run: npm run build
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,3 +30,18 @@ jobs:
 
       - run: npm ci
       - run: npm run lint
+
+  typecheck:
+    name: Typecheck (tsc --noEmit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+      - run: npx tsc --noEmit

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,32 @@
+name: Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
+
+defaults:
+  run:
+    working-directory: frontend
+
+jobs:
+  lint:
+    name: Lint (next lint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+      - run: npm run lint

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -62,3 +62,18 @@ jobs:
       - run: npm run build
         env:
           NEXT_TELEMETRY_DISABLED: '1'
+
+  test:
+    name: Test (jest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+      - run: npm test -- --ci --passWithNoTests

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Mirror the Conventional Commit types documented in CONTRIBUTING.md
+          types: |
+            feat
+            fix
+            docs
+            chore
+            test
+            refactor
+            perf
+            build
+            ci
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The PR title subject must start with a lowercase letter
+            (Conventional Commits style).


### PR DESCRIPTION
## Summary

Adds the first set of GitHub Actions workflows. The repo previously had no CI — only issue/PR templates under `.github/`.

Workflows added (one per concern, jobs added incrementally across 10 commits):

- **`frontend.yml`** — `next lint`, `tsc --noEmit`, `next build`, `jest` (path-filtered to `frontend/`)
- **`clarity.yml`** — `vitest` (clarinet-sdk) + `clarinet check` (binary pinned to v2.11.2)
- **`evm.yml`** — `hardhat compile`, `hardhat test`, `solhint`
- **`pr-title.yml`** — Conventional Commits lint, types mirror `CONTRIBUTING.md`
- **`dependency-review.yml`** — fail-on-high CVE, permissive-license allow-list

All workflows read Node from the root `.nvmrc` (added in #36) so CI matches local dev.

## Test plan

- [ ] Workflows show up in the Actions tab once merged
- [ ] `Frontend` runs on this PR (since it edits the path-filter for itself? — no, path filter is `frontend/**`, so it won't trigger; that's expected)
- [ ] `PR Title` runs against this PR's own title and passes
- [ ] `Dependency Review` runs and passes (no dependency changes here)
- [ ] After merge, open a trivial PR in each of `frontend/`, `smartcontracts/`, `smartcontracts-evm/` to verify the path filters fire

## Notes

- Clarinet binary version is pinned (`CLARINET_VERSION: '2.11.2'`). Bumping it is a deliberate one-line change.
- `jest` job uses `--passWithNoTests` so it does not fail while the frontend suite is still being built out (see PR 4 plan).
- `contributions/` is included in the EVM workflow path filter so V2 drafts still get a syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)