### PR TITLE
test(clarity): full vitest coverage for every contract, plus 2 bug pins

### DIFF
--- a/smartcontracts/tests/booking.test.ts
+++ b/smartcontracts/tests/booking.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+    uintCV,
+    stringUtf8CV,
+    stringAsciiCV,
+    boolCV,
+} from "@stacks/transactions";
+
+const accounts = simnet.getAccounts();
+const owner = accounts.get("wallet_1")!;
+const renter = accounts.get("wallet_2")!;
+const stranger = accounts.get("wallet_3")!;
+
+const BOOKING = "booking";
+const SPOT = "parking-spot";
+const REG = "user-registry";
+const CARS = "car-registry";
+
+// Each test must run setup itself: when this scaffold lives in a
+// vitest beforeEach hook it interleaves badly with the global
+// before-each from @stacks/clarinet-sdk and the spot ends up
+// missing by the time the test body runs. Inline setup is the
+// pattern the rest of the suite uses.
+function setup() {
+    simnet.callPublicFn(REG, "register-user", [], owner);
+    simnet.callPublicFn(REG, "register-user", [], renter);
+    simnet.callPublicFn(
+        CARS,
+        "register-car",
+        [stringAsciiCV("ABC-1"), stringAsciiCV("Make"), stringAsciiCV("Model"), uintCV(2020)],
+        renter,
+    );
+    simnet.callPublicFn(
+        SPOT,
+        "list-spot",
+        [stringUtf8CV("123 Main St"), uintCV(10)],
+        owner,
+    );
+}
+
+function createBooking(spotId: number, carId: number, start: number, end: number, sender = renter) {
+    return simnet.callPublicFn(
+        BOOKING,
+        "create-booking",
+        [uintCV(spotId), uintCV(carId), uintCV(start), uintCV(end)],
+        sender,
+    );
+}
+
+function stxBalance(addr: string): bigint {
+    return simnet.getAssetsMap().get("STX")?.get(addr) ?? 0n;
+}
+
+describe("booking", () => {
+    it("creates a booking, stores it, and registers it under the spot", () => {
+        setup();
+        const start = simnet.burnBlockHeight + 5;
+        const end = start + 4; // 4 blocks × 10 STX/block = 40 STX escrow
+
+        const { result } = createBooking(1, 1, start, end);
+        expect(result).toBeOk(uintCV(1));
+
+        const booking = simnet.callReadOnlyFn(BOOKING, "get-booking", [uintCV(1)], renter).result;
+        expect(booking).toHaveProperty("value.value.status", uintCV(0));
+        expect(booking).toHaveProperty("value.value.total-price", uintCV(40));
+        expect(booking).toHaveProperty("value.value.escrow-id", uintCV(1));
+    });
+
+    it("rejects a booking with start >= end", () => {
+        setup();
+        const { result } = createBooking(1, 1, 10, 10);
+        expect(result).toBeErr(uintCV(103)); // err-invalid-time-range
+    });
+
+    it("rejects a booking that starts in the past", () => {
+        setup();
+        const { result } = createBooking(1, 1, 1, 5);
+        expect(result).toBeErr(uintCV(104)); // err-start-time-in-past
+    });
+
+    it("rejects an owner trying to book their own spot", () => {
+        setup();
+        const start = simnet.burnBlockHeight + 5;
+        const { result } = createBooking(1, 1, start, start + 2, owner);
+        expect(result).toBeErr(uintCV(105)); // err-cannot-book-own-spot
+    });
+
+    it("rejects a booking that overlaps an existing one", () => {
+        setup();
+        const start = simnet.burnBlockHeight + 5;
+        createBooking(1, 1, start, start + 4);
+
+        const { result } = createBooking(1, 1, start + 1, start + 3);
+        expect(result).toBeErr(uintCV(106)); // err-time-slot-already-booked
+    });
+
+    it("rejects a booking when the spot has been marked unavailable", () => {
+        setup();
+        simnet.callPublicFn(SPOT, "update-spot-availability", [uintCV(1), boolCV(false)], owner);
+
+        const start = simnet.burnBlockHeight + 5;
+        const { result } = createBooking(1, 1, start, start + 2);
+        expect(result).toBeErr(uintCV(102)); // err-spot-not-available
+    });
+
+    it("rejects a booking against a spot that does not exist", () => {
+        setup();
+        const start = simnet.burnBlockHeight + 5;
+        const { result } = createBooking(999, 1, start, start + 2);
+        expect(result).toBeErr(uintCV(101)); // err-spot-not-found
+    });
+
+    it("lets the renter cancel before the booking starts and refunds the escrow", () => {
+        setup();
+        const start = simnet.burnBlockHeight + 20;
+        createBooking(1, 1, start, start + 4);
+
+        const renterBefore = stxBalance(renter);
+        const { result } = simnet.callPublicFn(BOOKING, "cancel-booking", [uintCV(1)], renter);
+        expect(result).toBeOk(boolCV(true));
+        expect(stxBalance(renter) - renterBefore).toBe(40n);
+    });
+
+    it("rejects cancel-booking from a stranger", () => {
+        setup();
+        const start = simnet.burnBlockHeight + 20;
+        createBooking(1, 1, start, start + 4);
+
+        const { result } = simnet.callPublicFn(BOOKING, "cancel-booking", [uintCV(1)], stranger);
+        expect(result).toBeErr(uintCV(100)); // err-not-authorized
+    });
+
+    it("releases escrowed funds to the owner on complete-booking after end time", () => {
+        setup();
+        const start = simnet.burnBlockHeight + 2;
+        const end = start + 4;
+        createBooking(1, 1, start, end);
+
+        // Advance past end-time so release-funds' release-time check passes.
+        simnet.mineEmptyBurnBlocks(end + 5);
+
+        const ownerBefore = stxBalance(owner);
+        // Must be called by the owner: the inner payment-escrow.release-funds
+        // restricts tx-sender to the payee or the contract-owner. The booking
+        // contract's own gate on complete-booking is looser (renter OR owner),
+        // but the underlying escrow rejects renter callers.
+        const { result } = simnet.callPublicFn(BOOKING, "complete-booking", [uintCV(1)], owner);
+        expect(result).toBeOk(boolCV(true));
+        expect(stxBalance(owner) - ownerBefore).toBe(40n);
+    });
+
+    it("BUG: complete-booking by the renter fails at the escrow release step", () => {
+        // booking.clar lets either the renter or the owner call complete-
+        // booking, but payment-escrow.release-funds only accepts the payee
+        // (the owner) or the deployer. So a renter calling complete-booking
+        // hits err-not-authorized (u200) from the inner contract-call.
+        // Fixing this means either tightening complete-booking to owner-only
+        // or wrapping the inner release-funds in `as-contract`.
+        setup();
+        const start = simnet.burnBlockHeight + 2;
+        const end = start + 4;
+        createBooking(1, 1, start, end);
+        simnet.mineEmptyBurnBlocks(end + 5);
+
+        const { result } = simnet.callPublicFn(BOOKING, "complete-booking", [uintCV(1)], renter);
+        expect(result).toBeErr(uintCV(200));
+    });
+});

--- a/smartcontracts/tests/car-registry.test.ts
+++ b/smartcontracts/tests/car-registry.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+    uintCV,
+    principalCV,
+    stringAsciiCV,
+    listCV,
+    tupleCV,
+} from "@stacks/transactions";
+
+const accounts = simnet.getAccounts();
+const alice = accounts.get("wallet_1")!;
+const bob = accounts.get("wallet_2")!;
+
+const REG = "car-registry";
+
+function registerCar(
+    plate: string,
+    make: string,
+    model: string,
+    year: number,
+    sender: string,
+) {
+    return simnet.callPublicFn(
+        REG,
+        "register-car",
+        [
+            stringAsciiCV(plate),
+            stringAsciiCV(make),
+            stringAsciiCV(model),
+            uintCV(year),
+        ],
+        sender,
+    );
+}
+
+function getCar(id: number) {
+    return simnet.callReadOnlyFn(REG, "get-car", [uintCV(id)], alice).result;
+}
+
+function ownerCars(addr: string) {
+    return simnet.callReadOnlyFn(REG, "get-owner-cars", [principalCV(addr)], addr).result;
+}
+
+describe("car-registry", () => {
+    it("registers a car and returns its id", () => {
+        const { result } = registerCar("ABC-123", "Toyota", "Corolla", 2020, alice);
+        expect(result).toBeOk(uintCV(1));
+
+        expect(getCar(1)).toBeSome(tupleCV({
+            "owner": principalCV(alice),
+            "plate-number": stringAsciiCV("ABC-123"),
+            "make": stringAsciiCV("Toyota"),
+            "model": stringAsciiCV("Corolla"),
+            "year": uintCV(2020),
+        }));
+    });
+
+    it("assigns monotonically-increasing car ids across owners", () => {
+        const a = registerCar("AAA-1", "Make", "Model", 2020, alice);
+        const b = registerCar("BBB-1", "Make", "Model", 2021, bob);
+        const c = registerCar("CCC-1", "Make", "Model", 2022, alice);
+
+        expect(a.result).toBeOk(uintCV(1));
+        expect(b.result).toBeOk(uintCV(2));
+        expect(c.result).toBeOk(uintCV(3));
+    });
+
+    it("appends new cars to the owner's list", () => {
+        registerCar("AAA-1", "Make", "Model", 2020, alice);
+        registerCar("AAA-2", "Make", "Model", 2021, alice);
+
+        expect(ownerCars(alice)).toStrictEqual(
+            listCV([uintCV(1), uintCV(2)]),
+        );
+    });
+
+    it("returns an empty list for an owner with no cars", () => {
+        expect(ownerCars(bob)).toStrictEqual(listCV([]));
+    });
+
+    it("returns none for an unknown car id", () => {
+        expect(getCar(999)).toBeNone();
+    });
+
+    it("lets the owner update their car's details", () => {
+        registerCar("ABC-123", "Toyota", "Corolla", 2020, alice);
+
+        const { result } = simnet.callPublicFn(
+            REG,
+            "update-car",
+            [
+                uintCV(1),
+                stringAsciiCV("XYZ-789"),
+                stringAsciiCV("Toyota"),
+                stringAsciiCV("Camry"),
+                uintCV(2023),
+            ],
+            alice,
+        );
+        expect(result).toBeOk(expect.anything());
+
+        expect(getCar(1)).toBeSome(tupleCV({
+            "owner": principalCV(alice),
+            "plate-number": stringAsciiCV("XYZ-789"),
+            "make": stringAsciiCV("Toyota"),
+            "model": stringAsciiCV("Camry"),
+            "year": uintCV(2023),
+        }));
+    });
+
+    it("rejects update-car from a non-owner", () => {
+        registerCar("ABC-123", "Toyota", "Corolla", 2020, alice);
+
+        const { result } = simnet.callPublicFn(
+            REG,
+            "update-car",
+            [
+                uintCV(1),
+                stringAsciiCV("HACK-1"),
+                stringAsciiCV("X"),
+                stringAsciiCV("Y"),
+                uintCV(1999),
+            ],
+            bob,
+        );
+        expect(result).toBeErr(uintCV(100)); // err-not-authorized
+    });
+
+    it("rejects update-car for an unknown car id", () => {
+        const { result } = simnet.callPublicFn(
+            REG,
+            "update-car",
+            [
+                uintCV(999),
+                stringAsciiCV("ABC"),
+                stringAsciiCV("X"),
+                stringAsciiCV("Y"),
+                uintCV(2000),
+            ],
+            alice,
+        );
+        expect(result).toBeErr(uintCV(101)); // err-car-not-found
+    });
+});

--- a/smartcontracts/tests/carin-rewards-token.test.ts
+++ b/smartcontracts/tests/carin-rewards-token.test.ts
@@ -1,20 +1,108 @@
 import { describe, expect, it } from "vitest";
+import {
+    uintCV,
+    principalCV,
+    stringAsciiCV,
+    noneCV,
+    someCV,
+    bufferCV,
+} from "@stacks/transactions";
 
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const deployer = accounts.get("deployer")!;
+const alice = accounts.get("wallet_1")!;
+const bob = accounts.get("wallet_2")!;
 
-/*
-The test below is an example. To learn more, read the testing documentation here:
-https://docs.stacks.co/clarinet/testing-with-clarinet-sdk
-*/
+const TOKEN = "carin-rewards-token";
 
-describe("example tests", () => {
-it("ensures simnet is well initialised", () => {
-    expect(simnet.blockHeight).toBeDefined();
-});
+function mint(amount: number, recipient: string, sender = deployer) {
+    return simnet.callPublicFn(
+        TOKEN,
+        "mint",
+        [uintCV(amount), principalCV(recipient)],
+        sender,
+    );
+}
 
-// it("shows an example", () => {
-//   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
-//   expect(result).toBeUint(0);
-// });
+function balance(addr: string) {
+    return simnet.callReadOnlyFn(TOKEN, "get-balance", [principalCV(addr)], addr).result;
+}
+
+describe("carin-rewards-token (SIP-010)", () => {
+    it("exposes the SIP-010 metadata", () => {
+        const name = simnet.callReadOnlyFn(TOKEN, "get-name", [], alice).result;
+        const symbol = simnet.callReadOnlyFn(TOKEN, "get-symbol", [], alice).result;
+        const decimals = simnet.callReadOnlyFn(TOKEN, "get-decimals", [], alice).result;
+        const uri = simnet.callReadOnlyFn(TOKEN, "get-token-uri", [], alice).result;
+
+        expect(name).toBeOk(stringAsciiCV("CarIn Rewards Token"));
+        expect(symbol).toBeOk(stringAsciiCV("CIRT"));
+        expect(decimals).toBeOk(uintCV(6));
+        expect(uri).toBeOk(noneCV());
+    });
+
+    it("starts every account at zero balance and zero total supply", () => {
+        expect(balance(alice)).toBeOk(uintCV(0));
+        const supply = simnet.callReadOnlyFn(TOKEN, "get-total-supply", [], alice).result;
+        expect(supply).toBeOk(uintCV(0));
+    });
+
+    it("lets the contract owner mint and updates balance + supply", () => {
+        const { result } = mint(1_000, alice);
+        expect(result).toBeOk(expect.anything());
+
+        expect(balance(alice)).toBeOk(uintCV(1_000));
+        const supply = simnet.callReadOnlyFn(TOKEN, "get-total-supply", [], alice).result;
+        expect(supply).toBeOk(uintCV(1_000));
+    });
+
+    it("rejects mint from a non-owner", () => {
+        const { result } = mint(500, alice, alice);
+        expect(result).toBeErr(uintCV(400)); // err-not-authorized
+    });
+
+    it("transfers tokens between accounts when called by the sender", () => {
+        mint(1_000, alice);
+
+        const { result } = simnet.callPublicFn(
+            TOKEN,
+            "transfer",
+            [uintCV(300), principalCV(alice), principalCV(bob), noneCV()],
+            alice,
+        );
+
+        expect(result).toBeOk(expect.anything());
+        expect(balance(alice)).toBeOk(uintCV(700));
+        expect(balance(bob)).toBeOk(uintCV(300));
+    });
+
+    it("rejects transfer when tx-sender is not the named sender", () => {
+        mint(1_000, alice);
+
+        const { result } = simnet.callPublicFn(
+            TOKEN,
+            "transfer",
+            [uintCV(100), principalCV(alice), principalCV(bob), noneCV()],
+            bob, // bob trying to move alice's tokens
+        );
+
+        expect(result).toBeErr(uintCV(400));
+        expect(balance(alice)).toBeOk(uintCV(1_000));
+        expect(balance(bob)).toBeOk(uintCV(0));
+    });
+
+    it("accepts a memo on transfer", () => {
+        mint(500, alice);
+        const memo = bufferCV(new Uint8Array([0x01, 0x02, 0x03]));
+
+        const { result } = simnet.callPublicFn(
+            TOKEN,
+            "transfer",
+            [uintCV(50), principalCV(alice), principalCV(bob), someCV(memo)],
+            alice,
+        );
+
+        expect(result).toBeOk(expect.anything());
+        expect(balance(bob)).toBeOk(uintCV(50));
+    });
 });

--- a/smartcontracts/tests/dispute-resolution.test.ts
+++ b/smartcontracts/tests/dispute-resolution.test.ts
@@ -1,20 +1,174 @@
 import { describe, expect, it } from "vitest";
+import {
+    uintCV,
+    principalCV,
+    stringUtf8CV,
+    stringAsciiCV,
+    boolCV,
+} from "@stacks/transactions";
 
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const deployer = accounts.get("deployer")!;
+const payer = accounts.get("wallet_1")!;
+const payee = accounts.get("wallet_2")!;
+const stranger = accounts.get("wallet_3")!;
 
-/*
-The test below is an example. To learn more, read the testing documentation here:
-https://docs.stacks.co/clarinet/testing-with-clarinet-sdk
-*/
+const DISPUTES = "dispute-resolution";
+const ESCROW = "payment-escrow";
 
-describe("example tests", () => {
-it("ensures simnet is well initialised", () => {
-    expect(simnet.blockHeight).toBeDefined();
-});
+function seedEscrow(amount = 1_000) {
+    return simnet.callPublicFn(
+        ESCROW,
+        "create-escrow",
+        [
+            uintCV(1),
+            principalCV(payee),
+            uintCV(amount),
+            uintCV(simnet.burnBlockHeight + 100),
+        ],
+        payer,
+    );
+}
 
-// it("shows an example", () => {
-//   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
-//   expect(result).toBeUint(0);
-// });
+function fileDispute(escrowId = 1, opposing = payee, sender = payer) {
+    return simnet.callPublicFn(
+        DISPUTES,
+        "file-dispute",
+        [
+            uintCV(escrowId),
+            uintCV(1),
+            principalCV(opposing),
+            stringUtf8CV("spot was inaccessible"),
+        ],
+        sender,
+    );
+}
+
+describe("dispute-resolution", () => {
+    it("files a dispute and locks the underlying escrow", () => {
+        seedEscrow();
+        const { result } = fileDispute();
+        expect(result).toBeOk(uintCV(1));
+
+        // Status on the escrow should now be status-disputed (u3),
+        // so refund-payer must fail with err-escrow-not-pending (u202).
+        const refund = simnet.callPublicFn(ESCROW, "refund-payer", [uintCV(1)], payer);
+        expect(refund.result).toBeErr(uintCV(202));
+    });
+
+    it("lets either party add evidence", () => {
+        seedEscrow();
+        fileDispute();
+
+        const filerEv = simnet.callPublicFn(
+            DISPUTES,
+            "add-evidence",
+            [uintCV(1), stringAsciiCV("0xabc123")],
+            payer,
+        );
+        const opposingEv = simnet.callPublicFn(
+            DISPUTES,
+            "add-evidence",
+            [uintCV(1), stringAsciiCV("0xdef456")],
+            payee,
+        );
+
+        expect(filerEv.result).toBeOk(uintCV(1));
+        expect(opposingEv.result).toBeOk(uintCV(2));
+    });
+
+    it("rejects evidence from an unrelated principal", () => {
+        seedEscrow();
+        fileDispute();
+
+        const { result } = simnet.callPublicFn(
+            DISPUTES,
+            "add-evidence",
+            [uintCV(1), stringAsciiCV("0xfeed")],
+            stranger,
+        );
+        expect(result).toBeErr(uintCV(300)); // err-not-authorized
+    });
+
+    it("rejects add-evidence for an unknown dispute id", () => {
+        const { result } = simnet.callPublicFn(
+            DISPUTES,
+            "add-evidence",
+            [uintCV(999), stringAsciiCV("0x00")],
+            payer,
+        );
+        expect(result).toBeErr(uintCV(301)); // err-dispute-not-found
+    });
+
+    it("lets the contract owner resolve the dispute in favour of the payer", () => {
+        seedEscrow(1_000);
+        fileDispute();
+
+        const payerBefore =
+            simnet.getAssetsMap().get("STX")?.get(payer) ?? 0n;
+
+        const { result } = simnet.callPublicFn(
+            DISPUTES,
+            "resolve-dispute",
+            [uintCV(1), boolCV(true)],
+            deployer,
+        );
+        expect(result).toBeOk(boolCV(true));
+
+        const payerAfter =
+            simnet.getAssetsMap().get("STX")?.get(payer) ?? 0n;
+        expect(payerAfter - payerBefore).toBe(1_000n);
+    });
+
+    it("rejects resolve-dispute from a non-owner", () => {
+        seedEscrow();
+        fileDispute();
+
+        const { result } = simnet.callPublicFn(
+            DISPUTES,
+            "resolve-dispute",
+            [uintCV(1), boolCV(true)],
+            stranger,
+        );
+        expect(result).toBeErr(uintCV(300));
+    });
+
+    it("rejects a second resolve-dispute on the same dispute", () => {
+        seedEscrow();
+        fileDispute();
+
+        simnet.callPublicFn(
+            DISPUTES,
+            "resolve-dispute",
+            [uintCV(1), boolCV(true)],
+            deployer,
+        );
+
+        const second = simnet.callPublicFn(
+            DISPUTES,
+            "resolve-dispute",
+            [uintCV(1), boolCV(true)],
+            deployer,
+        );
+        expect(second.result).toBeErr(uintCV(302)); // err-dispute-already-resolved
+    });
+
+    it("rejects add-evidence on a resolved dispute", () => {
+        seedEscrow();
+        fileDispute();
+        simnet.callPublicFn(
+            DISPUTES,
+            "resolve-dispute",
+            [uintCV(1), boolCV(false)],
+            deployer,
+        );
+
+        const { result } = simnet.callPublicFn(
+            DISPUTES,
+            "add-evidence",
+            [uintCV(1), stringAsciiCV("late")],
+            payer,
+        );
+        expect(result).toBeErr(uintCV(302));
+    });
 });

--- a/smartcontracts/tests/parking-spot.test.ts
+++ b/smartcontracts/tests/parking-spot.test.ts
@@ -66,4 +66,53 @@ describe("parking-spot", () => {
 
         expect(result).toBeErr(uintCV(100)); // err-not-owner
     });
+
+    it("rejects a listing with a zero price", () => {
+        const { result } = listSpot("123 Main St", 0, wallet1);
+        expect(result).toBeErr(uintCV(101)); // err-invalid-price
+    });
+
+    it("returns none for an unknown spot", () => {
+        expect(getSpot(999)).toBeNone();
+    });
+
+    it("returns none from get-spot-owner for an unknown spot", () => {
+        const { result } = simnet.callReadOnlyFn(
+            "parking-spot",
+            "get-spot-owner",
+            [uintCV(999)],
+            wallet1,
+        );
+        expect(result).toBeNone();
+    });
+
+    it("returns the owner from get-spot-owner for a listed spot", () => {
+        listSpot("123 Main St", 100, wallet1);
+        const { result } = simnet.callReadOnlyFn(
+            "parking-spot",
+            "get-spot-owner",
+            [uintCV(1)],
+            wallet2,
+        );
+        expect(result).toBeSome(principalCV(wallet1));
+    });
+
+    it("rejects updating availability on a non-existent spot", () => {
+        const { result } = simnet.callPublicFn(
+            "parking-spot",
+            "update-spot-availability",
+            [uintCV(999), boolCV(false)],
+            wallet1,
+        );
+        expect(result).toBeErr(uintCV(102)); // err-spot-not-found
+    });
+
+    it("assigns monotonically-increasing spot ids", () => {
+        const a = listSpot("A", 100, wallet1);
+        const b = listSpot("B", 200, wallet1);
+        const c = listSpot("C", 300, wallet2);
+        expect(a.result).toBeOk(uintCV(1));
+        expect(b.result).toBeOk(uintCV(2));
+        expect(c.result).toBeOk(uintCV(3));
+    });
 });

--- a/smartcontracts/tests/parking-spot.test.ts
+++ b/smartcontracts/tests/parking-spot.test.ts
@@ -2,91 +2,68 @@ import { describe, expect, it } from "vitest";
 import { stringUtf8CV, uintCV, principalCV, boolCV, tupleCV } from "@stacks/transactions";
 
 const accounts = simnet.getAccounts();
-const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
+function listSpot(location: string, price: number, sender: string) {
+    return simnet.callPublicFn(
+        "parking-spot",
+        "list-spot",
+        [stringUtf8CV(location), uintCV(price)],
+        sender,
+    );
+}
+
+function getSpot(id: number) {
+    return simnet.callReadOnlyFn("parking-spot", "get-spot", [uintCV(id)], wallet1).result;
+}
+
 describe("parking-spot", () => {
     it("allows a user to list a parking spot", () => {
-        const { result } = simnet.callPublicFn(
-            "parking-spot",
-            "list-spot",
-            [
-                stringUtf8CV("123 Main St"),
-                uintCV(100)
-            ],
-            wallet1
-        );
+        const listedAt = simnet.burnBlockHeight;
+        const { result } = listSpot("123 Main St", 100, wallet1);
 
         expect(result).toBeOk(uintCV(1));
-
-        const spotDetails = simnet.callReadOnlyFn(
-            "parking-spot",
-            "get-spot",
-            [uintCV(1)],
-            wallet1
-        );
-        expect(spotDetails.result).toBeSome(tupleCV({
+        expect(getSpot(1)).toBeSome(tupleCV({
             "owner": principalCV(wallet1),
             "location": stringUtf8CV("123 Main St"),
             "price-per-hour": uintCV(100),
             "is-available": boolCV(true),
-            "created-at": uintCV(0)
+            "created-at": uintCV(listedAt),
         }));
     });
 
-    it("allows a user to toggle spot availability", () => {
-        // First list a spot
-        simnet.callPublicFn(
-            "parking-spot",
-            "list-spot",
-            [
-                stringUtf8CV("123 Main St"),
-                uintCV(100)
-            ],
-            wallet1
-        );
+    it("allows the owner to update spot availability", () => {
+        const listedAt = simnet.burnBlockHeight;
+        listSpot("123 Main St", 100, wallet1);
 
-        // Toggle availability
         const { result } = simnet.callPublicFn(
             "parking-spot",
-            "toggle-availability",
+            "update-spot-availability",
             [uintCV(1), boolCV(false)],
-            wallet1
+            wallet1,
         );
 
         expect(result).toBeOk(boolCV(true));
-
-        const spotDetails = simnet.callReadOnlyFn(
-            "parking-spot",
-            "get-spot",
-            [uintCV(1)],
-            wallet1
-        );
-        // We know it drops to SOME data map. Just using string parsing for simplicity
-        expect(spotDetails.result).toHaveProperty('value.data.is-available', boolCV(false));
+        expect(getSpot(1)).toBeSome(tupleCV({
+            "owner": principalCV(wallet1),
+            "location": stringUtf8CV("123 Main St"),
+            "price-per-hour": uintCV(100),
+            "is-available": boolCV(false),
+            "created-at": uintCV(listedAt),
+        }));
     });
 
-    it("prevents non-owners from toggling availability", () => {
-        // First list a spot with wallet1
-        simnet.callPublicFn(
-            "parking-spot",
-            "list-spot",
-            [
-                stringUtf8CV("123 Main St"),
-                uintCV(100)
-            ],
-            wallet1
-        );
+    it("prevents non-owners from updating availability", () => {
+        listSpot("123 Main St", 100, wallet1);
 
-        // Try to toggle availability with wallet2
         const { result } = simnet.callPublicFn(
             "parking-spot",
-            "toggle-availability",
+            "update-spot-availability",
             [uintCV(1), boolCV(false)],
-            wallet2
+            wallet2,
         );
 
-        expect(result).toBeErr(uintCV(100)); // err-not-authorized
+        expect(result).toBeErr(uintCV(100)); // err-not-owner
     });
 });

--- a/smartcontracts/tests/payment-escrow.test.ts
+++ b/smartcontracts/tests/payment-escrow.test.ts
@@ -1,20 +1,149 @@
 import { describe, expect, it } from "vitest";
+import { uintCV, principalCV, boolCV } from "@stacks/transactions";
 
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const deployer = accounts.get("deployer")!;
+const payer = accounts.get("wallet_1")!;
+const payee = accounts.get("wallet_2")!;
+const stranger = accounts.get("wallet_3")!;
 
-/*
-The test below is an example. To learn more, read the testing documentation here:
-https://docs.stacks.co/clarinet/testing-with-clarinet-sdk
-*/
+const ESCROW = "payment-escrow";
 
-describe("example tests", () => {
-it("ensures simnet is well initialised", () => {
-    expect(simnet.blockHeight).toBeDefined();
-});
+function createEscrow(
+    bookingId: number,
+    payeeAddr: string,
+    amount: number,
+    releaseTime: number,
+    sender: string,
+) {
+    return simnet.callPublicFn(
+        ESCROW,
+        "create-escrow",
+        [uintCV(bookingId), principalCV(payeeAddr), uintCV(amount), uintCV(releaseTime)],
+        sender,
+    );
+}
 
-// it("shows an example", () => {
-//   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
-//   expect(result).toBeUint(0);
-// });
+function getStxBalance(addr: string): bigint {
+    return simnet.getAssetsMap().get("STX")?.get(addr) ?? 0n;
+}
+
+describe("payment-escrow", () => {
+    it("creates an escrow and locks the payer's STX", () => {
+        const startBal = getStxBalance(payer);
+        const { result } = createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 10, payer);
+
+        expect(result).toBeOk(uintCV(1));
+        expect(getStxBalance(payer)).toBe(startBal - 1_000n);
+    });
+
+    it("rejects an escrow with zero amount", () => {
+        const { result } = createEscrow(1, payee, 0, simnet.burnBlockHeight + 10, payer);
+        expect(result).toBeErr(uintCV(204)); // err-amount-mismatch
+    });
+
+    it("refuses to release funds before the release time", () => {
+        createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 100, payer);
+
+        const { result } = simnet.callPublicFn(
+            ESCROW,
+            "release-funds",
+            [uintCV(1)],
+            payee,
+        );
+        expect(result).toBeErr(uintCV(203)); // err-release-time-not-reached
+    });
+
+    it("releases funds to the payee once the release time has passed", () => {
+        createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 2, payer);
+        simnet.mineEmptyBurnBlocks(3);
+
+        const payeeBefore = getStxBalance(payee);
+        const { result } = simnet.callPublicFn(
+            ESCROW,
+            "release-funds",
+            [uintCV(1)],
+            payee,
+        );
+
+        expect(result).toBeOk(boolCV(true));
+        expect(getStxBalance(payee)).toBe(payeeBefore + 1_000n);
+    });
+
+    it("rejects release from a non-payee non-owner caller", () => {
+        createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 2, payer);
+        simnet.mineEmptyBurnBlocks(3);
+
+        const { result } = simnet.callPublicFn(
+            ESCROW,
+            "release-funds",
+            [uintCV(1)],
+            stranger,
+        );
+        expect(result).toBeErr(uintCV(200)); // err-not-authorized
+    });
+
+    it("refunds the payer on refund-payer and reports err-escrow-not-pending afterwards", () => {
+        createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 10, payer);
+
+        const payerBefore = getStxBalance(payer);
+        const refund = simnet.callPublicFn(ESCROW, "refund-payer", [uintCV(1)], payer);
+
+        expect(refund.result).toBeOk(boolCV(true));
+        expect(getStxBalance(payer)).toBe(payerBefore + 1_000n);
+
+        // Second refund attempt should fail because status is no longer pending.
+        const second = simnet.callPublicFn(ESCROW, "refund-payer", [uintCV(1)], payer);
+        expect(second.result).toBeErr(uintCV(202)); // err-escrow-not-pending
+    });
+
+    it("returns err-escrow-not-found for an unknown escrow id", () => {
+        const { result } = simnet.callPublicFn(ESCROW, "release-funds", [uintCV(999)], payee);
+        expect(result).toBeErr(uintCV(201));
+    });
+
+    it("lets the contract owner resolve a dispute by refunding the payer", () => {
+        createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 10, payer);
+        simnet.callPublicFn(ESCROW, "mark-disputed", [uintCV(1)], deployer);
+
+        const payerBefore = getStxBalance(payer);
+        const { result } = simnet.callPublicFn(
+            ESCROW,
+            "resolve-dispute",
+            [uintCV(1), boolCV(true)],
+            deployer,
+        );
+
+        expect(result).toBeOk(boolCV(true));
+        expect(getStxBalance(payer)).toBe(payerBefore + 1_000n);
+    });
+
+    it("lets the contract owner resolve a dispute by releasing to the payee", () => {
+        createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 10, payer);
+        simnet.callPublicFn(ESCROW, "mark-disputed", [uintCV(1)], deployer);
+
+        const payeeBefore = getStxBalance(payee);
+        const { result } = simnet.callPublicFn(
+            ESCROW,
+            "resolve-dispute",
+            [uintCV(1), boolCV(false)],
+            deployer,
+        );
+
+        expect(result).toBeOk(boolCV(true));
+        expect(getStxBalance(payee)).toBe(payeeBefore + 1_000n);
+    });
+
+    it("rejects resolve-dispute from a non-owner", () => {
+        createEscrow(1, payee, 1_000, simnet.burnBlockHeight + 10, payer);
+        simnet.callPublicFn(ESCROW, "mark-disputed", [uintCV(1)], deployer);
+
+        const { result } = simnet.callPublicFn(
+            ESCROW,
+            "resolve-dispute",
+            [uintCV(1), boolCV(true)],
+            stranger,
+        );
+        expect(result).toBeErr(uintCV(200));
+    });
 });

--- a/smartcontracts/tests/rewards-manager.test.ts
+++ b/smartcontracts/tests/rewards-manager.test.ts
@@ -1,20 +1,93 @@
 import { describe, expect, it } from "vitest";
+import { uintCV, principalCV } from "@stacks/transactions";
 
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const deployer = accounts.get("deployer")!;
+const alice = accounts.get("wallet_1")!;
+const stranger = accounts.get("wallet_2")!;
 
-/*
-The test below is an example. To learn more, read the testing documentation here:
-https://docs.stacks.co/clarinet/testing-with-clarinet-sdk
-*/
+const MANAGER = "rewards-manager";
+const TOKEN = "carin-rewards-token";
 
-describe("example tests", () => {
-it("ensures simnet is well initialised", () => {
-    expect(simnet.blockHeight).toBeDefined();
-});
+function addReward(user: string, amount: number, sender = deployer) {
+    return simnet.callPublicFn(
+        MANAGER,
+        "add-reward",
+        [principalCV(user), uintCV(amount)],
+        sender,
+    );
+}
 
-// it("shows an example", () => {
-//   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
-//   expect(result).toBeUint(0);
-// });
+function pending(user: string) {
+    return simnet.callReadOnlyFn(
+        MANAGER,
+        "get-pending-rewards",
+        [principalCV(user)],
+        deployer,
+    ).result;
+}
+
+describe("rewards-manager", () => {
+    it("lets the owner add pending rewards for a user", () => {
+        const { result } = addReward(alice, 100);
+        expect(result).toBeOk(expect.anything());
+        expect(pending(alice)).toBeUint(100);
+    });
+
+    it("accumulates pending rewards across multiple add-reward calls", () => {
+        addReward(alice, 100);
+        addReward(alice, 250);
+        expect(pending(alice)).toBeUint(350);
+    });
+
+    it("rejects add-reward from a non-owner", () => {
+        const { result } = addReward(alice, 100, stranger);
+        expect(result).toBeErr(uintCV(500)); // err-not-authorized
+    });
+
+    it("returns 0 pending for a user that was never rewarded", () => {
+        expect(pending(stranger)).toBeUint(0);
+    });
+
+    it("rejects claim-rewards when the user has no pending balance", () => {
+        const { result } = simnet.callPublicFn(MANAGER, "claim-rewards", [], stranger);
+        expect(result).toBeErr(uintCV(501)); // err-no-pending-rewards
+    });
+
+    it("lets the deployer claim their own pending rewards", () => {
+        // The deployer is both rewards-manager owner AND token owner, so the
+        // mint inside claim-rewards succeeds. This is the only currently
+        // working claim path — see the next test for the bug it exposes.
+        addReward(deployer, 500);
+
+        const { result } = simnet.callPublicFn(MANAGER, "claim-rewards", [], deployer);
+        expect(result).toBeOk(uintCV(500));
+
+        // pending is reset to 0 after a successful claim
+        expect(pending(deployer)).toBeUint(0);
+
+        // and the deployer was minted 500 tokens
+        const bal = simnet.callReadOnlyFn(
+            TOKEN,
+            "get-balance",
+            [principalCV(deployer)],
+            deployer,
+        ).result;
+        expect(bal).toBeOk(uintCV(500));
+    });
+
+    it("BUG: claim-rewards by a non-deployer user currently fails at the token mint step", () => {
+        // The token contract restricts mint to tx-sender == contract-owner,
+        // and tx-sender is preserved across the contract-call from
+        // rewards-manager. So a non-deployer user with pending rewards hits
+        // err-not-authorized (u400) coming from the token contract instead
+        // of receiving their tokens. The fix is either to wrap the mint in
+        // `as-contract` here or to whitelist .rewards-manager as a minter in
+        // the token contract. This test documents the broken behaviour so a
+        // future fix has an obvious assertion to flip.
+        addReward(alice, 200);
+
+        const { result } = simnet.callPublicFn(MANAGER, "claim-rewards", [], alice);
+        expect(result).toBeErr(uintCV(400));
+    });
 });

--- a/smartcontracts/tests/spot-reviews.test.ts
+++ b/smartcontracts/tests/spot-reviews.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+    uintCV,
+    stringUtf8CV,
+    stringAsciiCV,
+    boolCV,
+    principalCV,
+    tupleCV,
+} from "@stacks/transactions";
+
+const accounts = simnet.getAccounts();
+const owner = accounts.get("wallet_1")!;
+const renter = accounts.get("wallet_2")!;
+const other = accounts.get("wallet_3")!;
+
+const REVIEWS = "spot-reviews";
+
+function submitReview(bookingId: number, spotId: number, rating: number, comment: string, sender: string) {
+    return simnet.callPublicFn(
+        REVIEWS,
+        "submit-review",
+        [
+            uintCV(bookingId),
+            uintCV(spotId),
+            uintCV(rating),
+            stringUtf8CV(comment),
+        ],
+        sender,
+    );
+}
+
+function getSpotRating(spotId: number) {
+    return simnet.callReadOnlyFn(REVIEWS, "get-spot-rating", [uintCV(spotId)], renter).result;
+}
+
+describe("spot-reviews", () => {
+    it("submits a review and exposes it via get-review", () => {
+        const { result } = submitReview(1, 1, 5, "great spot", renter);
+        expect(result).toBeOk(uintCV(1));
+
+        const review = simnet.callReadOnlyFn(REVIEWS, "get-review", [uintCV(1)], renter).result;
+        expect(review).toBeSome(tupleCV({
+            "booking-id": uintCV(1),
+            "reviewer": principalCV(renter),
+            "spot-id": uintCV(1),
+            "rating": uintCV(5),
+            "comment": stringUtf8CV("great spot"),
+        }));
+    });
+
+    it("rejects ratings outside the 1..5 range", () => {
+        const zero = submitReview(1, 1, 0, "bad", renter);
+        const six = submitReview(2, 1, 6, "bad", renter);
+        expect(zero.result).toBeErr(uintCV(102)); // err-invalid-rating
+        expect(six.result).toBeErr(uintCV(102));
+    });
+
+    it("rejects a second review for the same booking", () => {
+        submitReview(1, 1, 5, "first", renter);
+        const second = submitReview(1, 1, 4, "second", other);
+        expect(second.result).toBeErr(uintCV(101)); // err-review-already-exists
+    });
+
+    it("computes a running average for the spot, scaled by 10", () => {
+        submitReview(1, 1, 5, "a", renter); // average = 50 (5.0)
+        submitReview(2, 1, 3, "b", other);  // (5+3)/2 = 4.0 → 40
+
+        expect(getSpotRating(1)).toBeSome(tupleCV({
+            "total-rating": uintCV(8),
+            "review-count": uintCV(2),
+            "average": uintCV(40),
+        }));
+    });
+
+    it("returns none for an unrated spot", () => {
+        expect(getSpotRating(999)).toBeNone();
+    });
+
+    it("integration: book → complete → review updates the spot's rating", () => {
+        // Set up the full graph: users registered, car registered, spot listed.
+        simnet.callPublicFn("user-registry", "register-user", [], owner);
+        simnet.callPublicFn("user-registry", "register-user", [], renter);
+        simnet.callPublicFn(
+            "car-registry",
+            "register-car",
+            [
+                stringAsciiCV("ABC-1"),
+                stringAsciiCV("Make"),
+                stringAsciiCV("Model"),
+                uintCV(2020),
+            ],
+            renter,
+        );
+        simnet.callPublicFn(
+            "parking-spot",
+            "list-spot",
+            [stringUtf8CV("Downtown"), uintCV(10)],
+            owner,
+        );
+
+        // Book the spot.
+        const start = simnet.burnBlockHeight + 2;
+        const end = start + 4;
+        const booking = simnet.callPublicFn(
+            "booking",
+            "create-booking",
+            [uintCV(1), uintCV(1), uintCV(start), uintCV(end)],
+            renter,
+        );
+        expect(booking.result).toBeOk(uintCV(1));
+
+        // Advance past end so escrow release-time passes; owner completes.
+        simnet.mineEmptyBurnBlocks(end + 5);
+        const complete = simnet.callPublicFn(
+            "booking",
+            "complete-booking",
+            [uintCV(1)],
+            owner,
+        );
+        expect(complete.result).toBeOk(boolCV(true));
+
+        // Renter leaves a 4-star review tied to booking 1 / spot 1.
+        const review = submitReview(1, 1, 4, "good", renter);
+        expect(review.result).toBeOk(uintCV(1));
+
+        // Spot rating updated: total=4, count=1, average=40 (4.0 scaled).
+        expect(getSpotRating(1)).toBeSome(tupleCV({
+            "total-rating": uintCV(4),
+            "review-count": uintCV(1),
+            "average": uintCV(40),
+        }));
+    });
+});

--- a/smartcontracts/tests/user-registry.test.ts
+++ b/smartcontracts/tests/user-registry.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+    uintCV,
+    principalCV,
+    boolCV,
+    tupleCV,
+} from "@stacks/transactions";
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const alice = accounts.get("wallet_1")!;
+const bob = accounts.get("wallet_2")!;
+
+const REG = "user-registry";
+
+function register(sender: string) {
+    return simnet.callPublicFn(REG, "register-user", [], sender);
+}
+
+function getUser(addr: string) {
+    return simnet.callReadOnlyFn(REG, "get-user", [principalCV(addr)], addr).result;
+}
+
+const initialProfile = tupleCV({
+    "is-verified": boolCV(false),
+    "total-bookings": uintCV(0),
+    "host-rating": uintCV(0),
+    "renter-rating": uintCV(0),
+    "total-host-reviews": uintCV(0),
+    "total-renter-reviews": uintCV(0),
+});
+
+describe("user-registry", () => {
+    it("registers a fresh user with zeroed profile fields", () => {
+        const { result } = register(alice);
+        expect(result).toBeOk(boolCV(true));
+        expect(getUser(alice)).toBeSome(initialProfile);
+    });
+
+    it("rejects a second registration for the same principal", () => {
+        register(alice);
+        const { result } = register(alice);
+        expect(result).toBeErr(uintCV(101)); // err-user-already-exists
+    });
+
+    it("returns none for an unknown user", () => {
+        expect(getUser(bob)).toBeNone();
+    });
+
+    it("lets the contract owner verify a registered user", () => {
+        register(alice);
+        const { result } = simnet.callPublicFn(
+            REG,
+            "verify-user",
+            [principalCV(alice)],
+            deployer,
+        );
+        expect(result).toBeOk(boolCV(true));
+
+        const verified = simnet.callReadOnlyFn(
+            REG,
+            "is-user-verified",
+            [principalCV(alice)],
+            alice,
+        ).result;
+        expect(verified).toStrictEqual(boolCV(true));
+    });
+
+    it("rejects verify-user from a non-owner", () => {
+        register(alice);
+        const { result } = simnet.callPublicFn(
+            REG,
+            "verify-user",
+            [principalCV(alice)],
+            bob,
+        );
+        expect(result).toBeErr(uintCV(100)); // err-not-authorized
+    });
+
+    it("rejects verify-user for an unregistered principal", () => {
+        const { result } = simnet.callPublicFn(
+            REG,
+            "verify-user",
+            [principalCV(bob)],
+            deployer,
+        );
+        expect(result).toBeErr(uintCV(102)); // err-user-not-found
+    });
+
+    it("increments total-bookings for a registered user", () => {
+        register(alice);
+        simnet.callPublicFn(REG, "increment-bookings", [principalCV(alice)], deployer);
+        simnet.callPublicFn(REG, "increment-bookings", [principalCV(alice)], deployer);
+
+        const user = getUser(alice);
+        expect(user).toHaveProperty(
+            "value.value.total-bookings",
+            uintCV(2),
+        );
+    });
+
+    it("computes a running average for host rating updates", () => {
+        register(alice);
+        // first review: rating 5 → average becomes 5 (stored as scaled units)
+        simnet.callPublicFn(
+            REG,
+            "update-rating",
+            [principalCV(alice), boolCV(true), uintCV(5)],
+            deployer,
+        );
+        // second review: rating 3 → average becomes (5+3)/2 = 4
+        simnet.callPublicFn(
+            REG,
+            "update-rating",
+            [principalCV(alice), boolCV(true), uintCV(3)],
+            deployer,
+        );
+
+        const user = getUser(alice);
+        expect(user).toHaveProperty("value.value.host-rating", uintCV(4));
+        expect(user).toHaveProperty("value.value.total-host-reviews", uintCV(2));
+    });
+
+    it("tracks host and renter ratings independently", () => {
+        register(alice);
+        simnet.callPublicFn(
+            REG,
+            "update-rating",
+            [principalCV(alice), boolCV(true), uintCV(5)],
+            deployer,
+        );
+        simnet.callPublicFn(
+            REG,
+            "update-rating",
+            [principalCV(alice), boolCV(false), uintCV(2)],
+            deployer,
+        );
+
+        const user = getUser(alice);
+        expect(user).toHaveProperty("value.value.host-rating", uintCV(5));
+        expect(user).toHaveProperty("value.value.renter-rating", uintCV(2));
+        expect(user).toHaveProperty("value.value.total-host-reviews", uintCV(1));
+        expect(user).toHaveProperty("value.value.total-renter-reviews", uintCV(1));
+    });
+
+    it("rejects update-rating for an unregistered principal", () => {
+        const { result } = simnet.callPublicFn(
+            REG,
+            "update-rating",
+            [principalCV(bob), boolCV(true), uintCV(5)],
+            deployer,
+        );
+        expect(result).toBeErr(uintCV(102));
+    });
+});


### PR DESCRIPTION
## Summary

Brings the Clarinet vitest suite from **4 stub tests + 3 broken parking-spot tests** (state before this branch) to **76 passing tests across all 9 contracts** plus a cross-contract integration test.

Final state on this branch (verified with \`npm test\` on the smartcontracts/ workspace):

\`\`\`
Test Files  9 passed (9)
     Tests  76 passed (76)
\`\`\`

## What's covered

| Contract | Tests |
| --- | --- |
| parking-spot | 9 (was 3 broken — see commit 1 for the function-name bug + simnet block-height fix) |
| payment-escrow | 10 (STX balance verified, not just status) |
| dispute-resolution | 8 (covers the cross-contract lock into payment-escrow) |
| carin-rewards-token | 7 (full SIP-010 metadata + transfer/mint auth) |
| rewards-manager | 7 (one test pins a real claim-rewards bug — see below) |
| user-registry | 10 |
| car-registry | 8 |
| booking | 11 (one test pins a second auth-mismatch bug — see below) |
| spot-reviews | 6 (last one is the cross-contract integration test) |

## Two real bugs surfaced by these tests

Both are deliberately asserted as failures so they show up as red the day they're fixed:

1. **rewards-manager.claim-rewards is broken for non-deployer users.** The token contract gates \`mint\` on \`tx-sender == contract-owner\`, and \`tx-sender\` is preserved across \`contract-call?\`. So a normal user with pending rewards hits \`(err u400)\` from the token instead of receiving CIRT. Fix is \`as-contract\` around the inner mint or whitelist \`.rewards-manager\` as a minter.

2. **booking.complete-booking is broken for renter callers.** The outer gate accepts renter OR owner, but the inner \`payment-escrow.release-funds\` only accepts payee (= owner) or deployer. So a renter calling \`complete-booking\` gets \`(err u200)\`. Fix is either tightening complete-booking to owner-only or wrapping the inner release-funds in \`as-contract\`.

Test files where the bugs are asserted: \`tests/rewards-manager.test.ts\` and \`tests/booking.test.ts\` — search for \"BUG:\".

## Test plan

- [ ] \`cd smartcontracts && npm ci && npm test\` → 76/76 pass
- [ ] When PR 2 (CI workflows) lands, the \`Clarity / Vitest\` job runs this suite automatically

## Notes for reviewers

- Setup is inline in each test, not in a vitest \`beforeEach\` hook. Using \`beforeEach\` interleaved badly with the global \`beforeEach\` from \`@stacks/clarinet-sdk\` and ended up wiping the fixture before the test body ran. Inline setup mirrors the pattern used in the original \`parking-spot.test.ts\`.
- Funds-moving paths assert STX balance deltas, not just response status, so a bug that updates a ledger entry but skips the transfer fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)