### PR TITLE
feat(frontend): typed contracts foundation + wire two read-only hooks

### DIFF
--- a/frontend/lib/config/contracts.ts
+++ b/frontend/lib/config/contracts.ts
@@ -1,29 +1,49 @@
 /**
- * Stacks network configuration and constants
+ * Backwards-compatible re-exports.
+ *
+ * The previous version of this file duplicated network and address
+ * config inline. The single source of truth now lives in
+ * `lib/contracts/network.ts`. Old imports keep working.
  */
 
+export {
+    getCarInNetwork,
+    getStacksNetwork,
+    getDeployerAddress,
+    getContractIdentifier,
+    getContractRef,
+    CARIN_CONTRACTS,
+    type CarInNetwork,
+    type CarInContractName,
+} from "../contracts/network";
+
+import { getCarInNetwork } from "../contracts/network";
+
+export type NetworkName = "mainnet" | "testnet";
+
 export const NETWORKS = {
-  testnet: {
-    name: "Stacks Testnet",
-    chainId: "testnet",
-  },
-  mainnet: {
-    name: "Stacks Mainnet",
-    chainId: "mainnet",
-  },
+    testnet: { name: "Stacks Testnet", chainId: "testnet" },
+    mainnet: { name: "Stacks Mainnet", chainId: "mainnet" },
 } as const;
 
-export type NetworkName = keyof typeof NETWORKS;
-
 export function getNetworkConfig(network: NetworkName = "testnet") {
-  return NETWORKS[network];
+    return NETWORKS[network];
 }
 
 export function isNetworkSupported(chainId: string): boolean {
-  return Object.values(NETWORKS).some(network => network.chainId === chainId);
+    return Object.values(NETWORKS).some((n) => n.chainId === chainId);
 }
 
+/**
+ * Kept for callers that still expect the old shape. Reads from the
+ * same env var as the new helpers so a deploy only has to set one
+ * variable.
+ */
 export const DISPUTE_RESOLUTION_ADDRESSES = {
-  testnet: process.env.NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS_TESTNET || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.dispute-resolution",
-  mainnet: process.env.NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS_MAINNET || "",
+    testnet: getCarInNetwork() === "testnet"
+        ? `${process.env.NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"}.dispute-resolution`
+        : "",
+    mainnet: getCarInNetwork() === "mainnet"
+        ? `${process.env.NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS || ""}.dispute-resolution`
+        : "",
 };

--- a/frontend/lib/contracts/booking.ts
+++ b/frontend/lib/contracts/booking.ts
@@ -1,0 +1,128 @@
+/**
+ * Typed surface for the `booking` Clarity contract.
+ *
+ * Mirrors parking-spot.ts: read-only calls are fully wired and
+ * return plain JS; write calls return a request object for
+ * @stacks/connect's openContractCall.
+ */
+
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    cvToValue,
+    type ClarityValue,
+} from "@stacks/transactions";
+
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapOptionalTuple, microStxToStx } from "./codec";
+
+export const BOOKING_STATUS = {
+    ACTIVE: 0,
+    CANCELLED: 1,
+    COMPLETED: 2,
+} as const;
+
+export type BookingStatus = (typeof BOOKING_STATUS)[keyof typeof BOOKING_STATUS];
+
+export interface BookingRecord {
+    id: number;
+    spotId: number;
+    user: string;
+    carId: number;
+    startTime: number;
+    endTime: number;
+    totalPriceMicroStx: bigint;
+    totalPrice: string;
+    checkInTime: number;
+    checkOutTime: number;
+    status: BookingStatus;
+    escrowId: number;
+}
+
+const REF = () => getContractRef("booking");
+
+export async function getBooking(
+    bookingId: number | bigint,
+    senderAddress?: string,
+): Promise<BookingRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-booking",
+        functionArgs: [uintCV(BigInt(bookingId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+
+    const totalPriceMicroStx = BigInt(tuple["total-price"] as bigint);
+    return {
+        id: Number(bookingId),
+        spotId: Number(tuple["spot-id"]),
+        user: String(tuple["user"]),
+        carId: Number(tuple["car-id"]),
+        startTime: Number(tuple["start-time"]),
+        endTime: Number(tuple["end-time"]),
+        totalPriceMicroStx,
+        totalPrice: microStxToStx(totalPriceMicroStx),
+        checkInTime: Number(tuple["check-in-time"]),
+        checkOutTime: Number(tuple["check-out-time"]),
+        status: Number(tuple["status"]) as BookingStatus,
+        escrowId: Number(tuple["escrow-id"]),
+    };
+}
+
+/** Returns the list of booking ids associated with a spot. */
+export async function getSpotBookings(
+    spotId: number | bigint,
+    senderAddress?: string,
+): Promise<number[]> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-spot-bookings",
+        functionArgs: [uintCV(BigInt(spotId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    // The contract returns a bare list (not wrapped in optional).
+    const ids = cvToValue(result as ClarityValue) as Array<bigint | number>;
+    return (ids ?? []).map(Number);
+}
+
+export function buildCreateBookingCall(args: {
+    spotId: number | bigint;
+    carId: number | bigint;
+    startTime: number | bigint;
+    endTime: number | bigint;
+}) {
+    return {
+        ...REF(),
+        functionName: "create-booking",
+        functionArgs: [
+            uintCV(BigInt(args.spotId)),
+            uintCV(BigInt(args.carId)),
+            uintCV(BigInt(args.startTime)),
+            uintCV(BigInt(args.endTime)),
+        ],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildCancelBookingCall(bookingId: number | bigint) {
+    return {
+        ...REF(),
+        functionName: "cancel-booking",
+        functionArgs: [uintCV(BigInt(bookingId))],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildCompleteBookingCall(bookingId: number | bigint) {
+    return {
+        ...REF(),
+        functionName: "complete-booking",
+        functionArgs: [uintCV(BigInt(bookingId))],
+        network: getStacksNetwork(),
+    };
+}

--- a/frontend/lib/contracts/carRegistry.ts
+++ b/frontend/lib/contracts/carRegistry.ts
@@ -1,0 +1,104 @@
+/**
+ * Typed surface for the `car-registry` Clarity contract.
+ */
+
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    stringAsciiCV,
+    standardPrincipalCV,
+    cvToValue,
+    type ClarityValue,
+} from "@stacks/transactions";
+
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapOptionalTuple } from "./codec";
+
+export interface CarRecord {
+    id: number;
+    owner: string;
+    plateNumber: string;
+    make: string;
+    model: string;
+    year: number;
+}
+
+const REF = () => getContractRef("carRegistry");
+
+export async function getCar(
+    carId: number | bigint,
+    senderAddress?: string,
+): Promise<CarRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-car",
+        functionArgs: [uintCV(BigInt(carId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+    return {
+        id: Number(carId),
+        owner: String(tuple["owner"]),
+        plateNumber: String(tuple["plate-number"]),
+        make: String(tuple["make"]),
+        model: String(tuple["model"]),
+        year: Number(tuple["year"]),
+    };
+}
+
+export async function getOwnerCarIds(
+    ownerAddress: string,
+    senderAddress?: string,
+): Promise<number[]> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-owner-cars",
+        functionArgs: [standardPrincipalCV(ownerAddress)],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    const ids = cvToValue(result as ClarityValue) as Array<bigint | number>;
+    return (ids ?? []).map(Number);
+}
+
+export function buildRegisterCarCall(args: {
+    plateNumber: string; // (string-ascii 20)
+    make: string;        // (string-ascii 50)
+    model: string;       // (string-ascii 50)
+    year: number;
+}) {
+    return {
+        ...REF(),
+        functionName: "register-car",
+        functionArgs: [
+            stringAsciiCV(args.plateNumber),
+            stringAsciiCV(args.make),
+            stringAsciiCV(args.model),
+            uintCV(BigInt(args.year)),
+        ],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildUpdateCarCall(args: {
+    carId: number | bigint;
+    plateNumber: string;
+    make: string;
+    model: string;
+    year: number;
+}) {
+    return {
+        ...REF(),
+        functionName: "update-car",
+        functionArgs: [
+            uintCV(BigInt(args.carId)),
+            stringAsciiCV(args.plateNumber),
+            stringAsciiCV(args.make),
+            stringAsciiCV(args.model),
+            uintCV(BigInt(args.year)),
+        ],
+        network: getStacksNetwork(),
+    };
+}

--- a/frontend/lib/contracts/codec.ts
+++ b/frontend/lib/contracts/codec.ts
@@ -1,0 +1,105 @@
+/**
+ * Thin wrappers around @stacks/transactions Clarity value (de)serialization.
+ *
+ * These exist so the contract modules and hooks don't have to import
+ * @stacks/transactions directly (and so the rest of the codebase has
+ * a single, ergonomic surface for moving between Clarity values and
+ * plain JS).
+ */
+
+import {
+    cvToValue,
+    type ClarityValue,
+    type TupleCV,
+    type SomeCV,
+    type ResponseOkCV,
+    type ResponseErrorCV,
+} from "@stacks/transactions";
+
+/**
+ * Unwrap a `(response ok err)` value. Returns the inner value if ok,
+ * throws an Error tagged with the error code if err.
+ *
+ * @stacks/transactions returns ClarityValue from read-only calls; this
+ * helper turns that into either the JS value you want or a thrown
+ * Error so call sites can use try/catch or .then().
+ */
+export function unwrapResponse<T = unknown>(cv: ClarityValue): T {
+    if (cv.type === "ok") {
+        return cvToValue((cv as ResponseOkCV).value) as T;
+    }
+    if (cv.type === "err") {
+        const errValue = cvToValue((cv as ResponseErrorCV).value);
+        throw new ContractError(errValue);
+    }
+    // Some read-only functions return a bare value (not wrapped in response)
+    return cvToValue(cv) as T;
+}
+
+/**
+ * Unwrap a `(optional T)` value. Returns the inner JS value if some,
+ * null if none.
+ */
+export function unwrapOptional<T = unknown>(cv: ClarityValue): T | null {
+    if (cv.type === "some") {
+        return cvToValue((cv as SomeCV).value) as T;
+    }
+    if (cv.type === "none") {
+        return null;
+    }
+    // Caller passed something that wasn't an optional — treat as a plain value.
+    return cvToValue(cv) as T;
+}
+
+/**
+ * Convenience: unwrap an `(optional (tuple ...))` returning either the
+ * tuple as a plain JS object or null.
+ */
+export function unwrapOptionalTuple(cv: ClarityValue): Record<string, unknown> | null {
+    return unwrapOptional<Record<string, unknown>>(cv);
+}
+
+/**
+ * Convert a TupleCV directly to a plain object. Useful when the
+ * read-only function returns a bare tuple, not wrapped in optional or
+ * response.
+ */
+export function tupleToObject(cv: TupleCV): Record<string, unknown> {
+    return cvToValue(cv) as Record<string, unknown>;
+}
+
+/**
+ * Error type thrown by `unwrapResponse` when the Clarity response is
+ * an `err`. The numeric `code` is the value that came back from the
+ * contract — match it against the contract's `define-constant
+ * err-... (err uXXX)` codes to render a useful message.
+ */
+export class ContractError extends Error {
+    code: bigint | number | string;
+
+    constructor(code: bigint | number | string, message?: string) {
+        super(message ?? `Contract returned err ${String(code)}`);
+        this.name = "ContractError";
+        this.code = code;
+    }
+}
+
+/**
+ * Convert microSTX (1 STX = 1_000_000 µSTX) to a decimal STX string.
+ */
+export function microStxToStx(microStx: bigint | number | string): string {
+    const value = BigInt(microStx);
+    const stx = Number(value) / 1_000_000;
+    return stx.toFixed(6).replace(/\.?0+$/, "");
+}
+
+/**
+ * Convert a decimal STX string ("1.5") to microSTX (1_500_000n).
+ */
+export function stxToMicroStx(stx: string | number): bigint {
+    const asNumber = typeof stx === "string" ? Number(stx) : stx;
+    if (!Number.isFinite(asNumber) || asNumber < 0) {
+        throw new Error(`invalid STX amount: ${stx}`);
+    }
+    return BigInt(Math.round(asNumber * 1_000_000));
+}

--- a/frontend/lib/contracts/disputeResolution.ts
+++ b/frontend/lib/contracts/disputeResolution.ts
@@ -1,62 +1,211 @@
 /**
- * DisputeResolution Contract Interface for Stacks
- * Contract name and function definitions for Stacks Clarity contract
+ * Typed surface for the `dispute-resolution` Clarity contract.
+ *
+ * The previous version of this file declared a much larger
+ * DisputeDetails shape than the deployed Clarity contract actually
+ * supports (resolved-by, refund-percentage, votes, …). Those fields
+ * were never on chain — they belonged to the older EVM design. The
+ * record below matches the actual on-chain shape.
  */
 
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    boolCV,
+    stringUtf8CV,
+    stringAsciiCV,
+    standardPrincipalCV,
+} from "@stacks/transactions";
+
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapOptionalTuple } from "./codec";
+
+export const DISPUTE_STATUS = {
+    PENDING: 0,
+    RESOLVED: 1,
+} as const;
+
+export type DisputeStatus = (typeof DISPUTE_STATUS)[keyof typeof DISPUTE_STATUS];
+
+export interface DisputeRecord {
+    id: number;
+    escrowId: number;
+    bookingId: number;
+    filedBy: string;
+    opposingParty: string;
+    reason: string;
+    status: DisputeStatus;
+}
+
+export interface EvidenceRecord {
+    id: number;
+    disputeId: number;
+    submittedBy: string;
+    evidenceHash: string;
+}
+
+const REF = () => getContractRef("disputeResolution");
+
+export async function getDispute(
+    disputeId: number | bigint,
+    senderAddress?: string,
+): Promise<DisputeRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-dispute",
+        functionArgs: [uintCV(BigInt(disputeId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+    return {
+        id: Number(disputeId),
+        escrowId: Number(tuple["escrow-id"]),
+        bookingId: Number(tuple["booking-id"]),
+        filedBy: String(tuple["filed-by"]),
+        opposingParty: String(tuple["opposing-party"]),
+        reason: String(tuple["reason"]),
+        status: Number(tuple["status"]) as DisputeStatus,
+    };
+}
+
+export async function getEvidence(
+    evidenceId: number | bigint,
+    senderAddress?: string,
+): Promise<EvidenceRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-evidence",
+        functionArgs: [uintCV(BigInt(evidenceId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+    return {
+        id: Number(evidenceId),
+        disputeId: Number(tuple["dispute-id"]),
+        submittedBy: String(tuple["submitted-by"]),
+        evidenceHash: String(tuple["evidence-hash"]),
+    };
+}
+
+export function buildFileDisputeCall(args: {
+    escrowId: number | bigint;
+    bookingId: number | bigint;
+    opposingPartyAddress: string;
+    reason: string;
+}) {
+    return {
+        ...REF(),
+        functionName: "file-dispute",
+        functionArgs: [
+            uintCV(BigInt(args.escrowId)),
+            uintCV(BigInt(args.bookingId)),
+            standardPrincipalCV(args.opposingPartyAddress),
+            stringUtf8CV(args.reason),
+        ],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildAddEvidenceCall(args: {
+    disputeId: number | bigint;
+    evidenceHash: string; // (string-ascii 64) — pass the IPFS CID or hex digest
+}) {
+    return {
+        ...REF(),
+        functionName: "add-evidence",
+        functionArgs: [
+            uintCV(BigInt(args.disputeId)),
+            stringAsciiCV(args.evidenceHash),
+        ],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildResolveDisputeCall(args: {
+    disputeId: number | bigint;
+    refundPayer: boolean;
+}) {
+    return {
+        ...REF(),
+        functionName: "resolve-dispute",
+        functionArgs: [uintCV(BigInt(args.disputeId)), boolCV(args.refundPayer)],
+        network: getStacksNetwork(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy exports — these reflect the older (EVM-era) shape and are kept so
+// components that haven't been migrated yet still compile. They describe
+// fields that are NOT present in the deployed Clarity contract; new code
+// should use DisputeRecord / EvidenceRecord above.
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use the env-driven helpers in `./network` instead. */
 export const DISPUTE_RESOLUTION_CONTRACT = "dispute-resolution";
 
-// Contract addresses for Stacks
+/** @deprecated Use `getContractIdentifier('disputeResolution')`. */
 export const DISPUTE_RESOLUTION_ADDRESSES = {
-  testnet: process.env.NEXT_PUBLIC_STACKS_DISPUTE_ADDRESS_TESTNET || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
-  mainnet: process.env.NEXT_PUBLIC_STACKS_DISPUTE_ADDRESS_MAINNET || ""
+    testnet:
+        process.env.NEXT_PUBLIC_STACKS_DISPUTE_ADDRESS_TESTNET ||
+        "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+    mainnet: process.env.NEXT_PUBLIC_STACKS_DISPUTE_ADDRESS_MAINNET || "",
 };
 
+/** @deprecated EVM-era enum, the on-chain Clarity contract has no equivalent. */
 export enum ResolutionType {
-  Automated = 0,
-  PendingVote = 1,
-  Manual = 2
+    Automated = 0,
+    PendingVote = 1,
+    Manual = 2,
 }
 
+/** @deprecated Use DisputeRecord. */
 export interface DisputeDetails {
-  disputeId: string; // Using string for large unit ids in Stacks
-  escrowId: string;
-  bookingId: string;
-  filedBy: string;
-  opposingParty: string;
-  reason: string;
-  primaryEvidenceHash: string;
-  filedAt: number;
-  resolutionType: ResolutionType;
-  isResolved: boolean;
-  resolvedBy: string;
-  resolvedAt: number;
-  refundApproved: boolean;
-  refundPercentage: number;
+    disputeId: string;
+    escrowId: string;
+    bookingId: string;
+    filedBy: string;
+    opposingParty: string;
+    reason: string;
+    primaryEvidenceHash: string;
+    filedAt: number;
+    resolutionType: ResolutionType;
+    isResolved: boolean;
+    resolvedBy: string;
+    resolvedAt: number;
+    refundApproved: boolean;
+    refundPercentage: number;
 }
 
+/** @deprecated Use EvidenceRecord. */
 export interface Evidence {
-  evidenceId: string;
-  disputeId: string;
-  submittedBy: string;
-  evidenceType: number;
-  evidenceHash: string;
-  timestamp: number;
-  description: string;
+    evidenceId: string;
+    disputeId: string;
+    submittedBy: string;
+    evidenceType: number;
+    evidenceHash: string;
+    timestamp: number;
+    description: string;
 }
 
+/** @deprecated EVM-era shape, not on chain. */
 export interface CheckInData {
-  bookingId: string;
-  checkInTime: number;
-  checkOutTime: number;
-  checkedIn: boolean;
-  checkedOut: boolean;
-  verifiedBy: string;
+    bookingId: string;
+    checkInTime: number;
+    checkOutTime: number;
+    checkedIn: boolean;
+    checkedOut: boolean;
+    verifiedBy: string;
 }
 
+/** @deprecated EVM-era shape, not on chain. */
 export interface Vote {
-  voter: string;
-  supportsRefund: boolean;
-  weight: string;
-  timestamp: number;
-  justification: string;
+    voter: string;
+    supportsRefund: boolean;
+    weight: string;
+    timestamp: number;
+    justification: string;
 }

--- a/frontend/lib/contracts/network.ts
+++ b/frontend/lib/contracts/network.ts
@@ -1,0 +1,88 @@
+/**
+ * Single source of truth for which Stacks network we talk to and
+ * where the CarIn contracts live on it.
+ *
+ * The deployer address comes from `NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS`.
+ * Set this when you deploy. If unset, we fall back to the standard
+ * Clarinet simnet deployer address (ST1PQH…), which is only useful
+ * for local dev — read-only calls against testnet/mainnet will fail
+ * loudly if the env var isn't set, which is the desired behaviour.
+ *
+ * Network selection is driven by `NEXT_PUBLIC_STACKS_NETWORK`
+ * (`mainnet` | `testnet` | `devnet`). The previous
+ * `NEXT_PUBLIC_NETWORK` name is also accepted for backwards
+ * compatibility with the older constants/contracts.ts.
+ */
+
+import {
+    STACKS_MAINNET,
+    STACKS_TESTNET,
+    STACKS_DEVNET,
+    type StacksNetwork,
+} from "@stacks/network";
+
+export type CarInNetwork = "mainnet" | "testnet" | "devnet";
+
+const FALLBACK_DEPLOYER_ADDRESS = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+
+export function getCarInNetwork(): CarInNetwork {
+    const raw =
+        process.env.NEXT_PUBLIC_STACKS_NETWORK ||
+        process.env.NEXT_PUBLIC_NETWORK ||
+        "testnet";
+    if (raw === "mainnet" || raw === "testnet" || raw === "devnet") return raw;
+    return "testnet";
+}
+
+export function getStacksNetwork(): StacksNetwork {
+    switch (getCarInNetwork()) {
+        case "mainnet":
+            return STACKS_MAINNET;
+        case "devnet":
+            return STACKS_DEVNET;
+        case "testnet":
+        default:
+            return STACKS_TESTNET;
+    }
+}
+
+export function getDeployerAddress(): string {
+    return (
+        process.env.NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS ||
+        FALLBACK_DEPLOYER_ADDRESS
+    );
+}
+
+export const CARIN_CONTRACTS = {
+    parkingSpot: "parking-spot",
+    booking: "booking",
+    paymentEscrow: "payment-escrow",
+    disputeResolution: "dispute-resolution",
+    spotReviews: "spot-reviews",
+    userRegistry: "user-registry",
+    carRegistry: "car-registry",
+    carinRewardsToken: "carin-rewards-token",
+    rewardsManager: "rewards-manager",
+} as const;
+
+export type CarInContractName = keyof typeof CARIN_CONTRACTS;
+
+/**
+ * Build the fully-qualified identifier (deployer.contract-name) for a
+ * given contract. Useful for logs, links, and any API that wants a
+ * single string.
+ */
+export function getContractIdentifier(contract: CarInContractName): string {
+    return `${getDeployerAddress()}.${CARIN_CONTRACTS[contract]}`;
+}
+
+/**
+ * Split form ({ address, name }) used by `fetchCallReadOnlyFunction`
+ * and `openContractCall` from @stacks/transactions / @stacks/connect.
+ */
+export function getContractRef(contract: CarInContractName) {
+    return {
+        contractAddress: getDeployerAddress(),
+        contractName: CARIN_CONTRACTS[contract],
+    };
+}

--- a/frontend/lib/contracts/parkingSpot.ts
+++ b/frontend/lib/contracts/parkingSpot.ts
@@ -1,37 +1,119 @@
 /**
- * ParkingSpot contract constants and utilities for Stacks
+ * Typed surface for the `parking-spot` Clarity contract.
+ *
+ * Read-only calls (get-spot, get-spot-owner) are fully wired and
+ * return plain JS objects. Write calls (list-spot,
+ * update-spot-availability) return a request descriptor that the
+ * caller passes into @stacks/connect's `openContractCall` (the
+ * wallet is what actually signs and broadcasts, so this module
+ * never imports @stacks/connect directly).
  */
 
-// Contract addresses for Stacks
-export const PARKING_SPOT_ADDRESSES = {
-  testnet: process.env.NEXT_PUBLIC_PARKING_SPOT_ADDRESS_TESTNET || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.parking-spot",
-  mainnet: process.env.NEXT_PUBLIC_PARKING_SPOT_ADDRESS_MAINNET || "",
-};
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    stringUtf8CV,
+    boolCV,
+    standardPrincipalCV,
+    type ClarityValue,
+} from "@stacks/transactions";
 
-export interface ParkingSpot {
-  id: string;
-  owner: string;
-  location: string;
-  pricePerHour: string;
-  isAvailable: boolean;
-  createdAt: number;
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapOptionalTuple, microStxToStx } from "./codec";
+
+export interface ParkingSpotRecord {
+    id: number;
+    owner: string;
+    location: string;
+    pricePerHourMicroStx: bigint;
+    pricePerHour: string; // human-readable STX, e.g. "2.5"
+    isAvailable: boolean;
+    createdAtBurnHeight: number;
+}
+
+const REF = () => getContractRef("parkingSpot");
+
+/** Returns null if the spot does not exist. */
+export async function getSpot(
+    spotId: number | bigint,
+    senderAddress?: string,
+): Promise<ParkingSpotRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-spot",
+        functionArgs: [uintCV(BigInt(spotId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+
+    const microStx = BigInt(tuple["price-per-hour"] as bigint);
+    return {
+        id: Number(spotId),
+        owner: String(tuple["owner"]),
+        location: String(tuple["location"]),
+        pricePerHourMicroStx: microStx,
+        pricePerHour: microStxToStx(microStx),
+        isAvailable: Boolean(tuple["is-available"]),
+        createdAtBurnHeight: Number(tuple["created-at"]),
+    };
+}
+
+/** Returns null if the spot does not exist. */
+export async function getSpotOwner(
+    spotId: number | bigint,
+    senderAddress?: string,
+): Promise<string | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-spot-owner",
+        functionArgs: [uintCV(BigInt(spotId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+
+    if (result.type === "some") {
+        return String((result as { value: ClarityValue }).value);
+    }
+    return null;
 }
 
 /**
- * Mock function to get spot details from Stacks
+ * Build a `list-spot` contract-call request. Pass this into
+ * `openContractCall` from @stacks/connect.
+ *
+ *     openContractCall({ ...buildListSpotCall({ ... }), onFinish, onCancel })
  */
-export async function getSpotDetails(
-  spotId: string,
-  network: "testnet" | "mainnet" = "testnet"
-): Promise<ParkingSpot> {
-  console.log(`Fetching Stacks spot ${spotId} on ${network}...`);
-  // Mock implementation
-  return {
-    id: spotId,
-    owner: "ST1PQ...",
-    location: "San Francisco, CA",
-    pricePerHour: "5000000", // 5 STX in uSTX
-    isAvailable: true,
-    createdAt: Math.floor(Date.now() / 1000) - 86400,
-  };
+export function buildListSpotCall(args: {
+    location: string;
+    pricePerHourMicroStx: bigint | number | string;
+}) {
+    return {
+        ...REF(),
+        functionName: "list-spot",
+        functionArgs: [
+            stringUtf8CV(args.location),
+            uintCV(BigInt(args.pricePerHourMicroStx)),
+        ],
+        network: getStacksNetwork(),
+    };
 }
+
+/** Build an `update-spot-availability` contract-call request. */
+export function buildUpdateAvailabilityCall(args: {
+    spotId: number | bigint;
+    isAvailable: boolean;
+}) {
+    return {
+        ...REF(),
+        functionName: "update-spot-availability",
+        functionArgs: [uintCV(BigInt(args.spotId)), boolCV(args.isAvailable)],
+        network: getStacksNetwork(),
+    };
+}
+
+// Re-export the principal helper so call sites that need to pass a
+// principal as a function arg don't have to import @stacks/transactions.
+export { standardPrincipalCV };

--- a/frontend/lib/contracts/paymentEscrow.ts
+++ b/frontend/lib/contracts/paymentEscrow.ts
@@ -1,40 +1,112 @@
 /**
- * PaymentEscrow contract constants and utilities for Stacks
+ * Typed surface for the `payment-escrow` Clarity contract.
  */
 
-// Contract addresses for Stacks
-export const PAYMENT_ESCROW_ADDRESSES = {
-  testnet: process.env.NEXT_PUBLIC_PAYMENT_ESCROW_ADDRESS_TESTNET || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.payment-escrow",
-  mainnet: process.env.NEXT_PUBLIC_PAYMENT_ESCROW_ADDRESS_MAINNET || "",
-};
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    boolCV,
+    standardPrincipalCV,
+} from "@stacks/transactions";
 
-export interface EscrowDetails {
-  escrowId: string;
-  bookingId: string;
-  payer: string;
-  payee: string;
-  amount: string;
-  token?: string;
-  releaseTime: number;
-  status: number;
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapOptionalTuple, microStxToStx } from "./codec";
+
+export const ESCROW_STATUS = {
+    PENDING: 0,
+    RELEASED: 1,
+    REFUNDED: 2,
+    DISPUTED: 3,
+} as const;
+
+export type EscrowStatus = (typeof ESCROW_STATUS)[keyof typeof ESCROW_STATUS];
+
+export interface EscrowRecord {
+    id: number;
+    bookingId: number;
+    payer: string;
+    payee: string;
+    amountMicroStx: bigint;
+    amount: string;
+    releaseTime: number;
+    status: EscrowStatus;
 }
 
-/**
- * Mock function to get escrow details from Stacks
- */
-export async function getEscrowDetails(
-  escrowId: string,
-  network: "testnet" | "mainnet" = "testnet"
-): Promise<EscrowDetails> {
-  console.log(`Fetching Stacks escrow ${escrowId} on ${network}...`);
-  // Mock implementation
-  return {
-    escrowId,
-    bookingId: "BOOK-123",
-    payer: "ST1PQ...",
-    payee: "ST2ABC...",
-    amount: "1000000",
-    releaseTime: Math.floor(Date.now() / 1000) + 3600,
-    status: 1,
-  };
+const REF = () => getContractRef("paymentEscrow");
+
+export async function getEscrow(
+    escrowId: number | bigint,
+    senderAddress?: string,
+): Promise<EscrowRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-escrow",
+        functionArgs: [uintCV(BigInt(escrowId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+
+    const amount = BigInt(tuple["amount"] as bigint);
+    return {
+        id: Number(escrowId),
+        bookingId: Number(tuple["booking-id"]),
+        payer: String(tuple["payer"]),
+        payee: String(tuple["payee"]),
+        amountMicroStx: amount,
+        amount: microStxToStx(amount),
+        releaseTime: Number(tuple["release-time"]),
+        status: Number(tuple["status"]) as EscrowStatus,
+    };
+}
+
+export function buildCreateEscrowCall(args: {
+    bookingId: number | bigint;
+    payeeAddress: string;
+    amountMicroStx: bigint | number | string;
+    releaseTime: number | bigint;
+}) {
+    return {
+        ...REF(),
+        functionName: "create-escrow",
+        functionArgs: [
+            uintCV(BigInt(args.bookingId)),
+            standardPrincipalCV(args.payeeAddress),
+            uintCV(BigInt(args.amountMicroStx)),
+            uintCV(BigInt(args.releaseTime)),
+        ],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildReleaseFundsCall(escrowId: number | bigint) {
+    return {
+        ...REF(),
+        functionName: "release-funds",
+        functionArgs: [uintCV(BigInt(escrowId))],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildRefundPayerCall(escrowId: number | bigint) {
+    return {
+        ...REF(),
+        functionName: "refund-payer",
+        functionArgs: [uintCV(BigInt(escrowId))],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildResolveDisputeCall(args: {
+    escrowId: number | bigint;
+    refundPayer: boolean;
+}) {
+    return {
+        ...REF(),
+        functionName: "resolve-dispute",
+        functionArgs: [uintCV(BigInt(args.escrowId)), boolCV(args.refundPayer)],
+        network: getStacksNetwork(),
+    };
 }

--- a/frontend/lib/contracts/rewardsManager.ts
+++ b/frontend/lib/contracts/rewardsManager.ts
@@ -1,34 +1,59 @@
 /**
- * RewardsManager contract constants and utilities for Stacks
+ * Typed surface for the `rewards-manager` Clarity contract.
  */
 
-// Contract addresses for Stacks
-export const REWARDS_MANAGER_ADDRESSES = {
-  testnet: process.env.NEXT_PUBLIC_REWARDS_MANAGER_ADDRESS_TESTNET || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.rewards-manager",
-  mainnet: process.env.NEXT_PUBLIC_REWARDS_MANAGER_ADDRESS_MAINNET || "",
-};
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    standardPrincipalCV,
+    cvToValue,
+    type ClarityValue,
+} from "@stacks/transactions";
 
-// Reward types enum
-export enum RewardType {
-  InaccuracyReport = 0,
-  SpotShare = 1,
-  Referral = 2,
-  CommunityContribution = 3,
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+
+const REF = () => getContractRef("rewardsManager");
+
+export async function getPendingRewards(
+    address: string,
+    senderAddress?: string,
+): Promise<bigint> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-pending-rewards",
+        functionArgs: [standardPrincipalCV(address)],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    // Returns a bare uint (not optional, not response).
+    return BigInt(cvToValue(result as ClarityValue) as bigint | number);
 }
 
-/**
- * Interface for Stacks-based rewards management
- */
-export interface StacksRewardSession {
-  stxAddress: string;
-  network: "testnet" | "mainnet";
+export function buildAddRewardCall(args: {
+    userAddress: string;
+    amount: bigint | number | string;
+}) {
+    return {
+        ...REF(),
+        functionName: "add-reward",
+        functionArgs: [
+            standardPrincipalCV(args.userAddress),
+            uintCV(BigInt(args.amount)),
+        ],
+        network: getStacksNetwork(),
+    };
 }
 
-// Mock hash function (Stacks uses SipHash or SHA-256 differently, but for types we just need string)
-export function calculateReferralHash(
-  referrer: string,
-  referee: string,
-  spotId: string
-): string {
-  return `REF-${referrer.slice(-4)}-${referee.slice(-4)}-${spotId}`;
+export function buildClaimRewardsCall() {
+    return {
+        ...REF(),
+        functionName: "claim-rewards",
+        functionArgs: [],
+        network: getStacksNetwork(),
+    };
+    // NOTE: as of the current deployment, claim-rewards reverts for
+    // anyone except the deployer because of an auth check in the
+    // underlying carin-rewards-token.mint. See PR 3's
+    // tests/rewards-manager.test.ts BUG: test for details. The build
+    // helper above stays useful for the eventual fix.
 }

--- a/frontend/lib/contracts/rewardsToken.ts
+++ b/frontend/lib/contracts/rewardsToken.ts
@@ -1,17 +1,102 @@
 /**
- * RewardsToken Contract Interface for Stacks (SIP-010)
+ * Typed surface for the `carin-rewards-token` Clarity contract (SIP-010).
+ *
+ * Note: the previous version of this file claimed the contract
+ * name was "carin-token", which is wrong — the Clarinet manifest
+ * names it `carin-rewards-token`. The single source of truth now
+ * lives in `./network`.
  */
 
-export const REWARDS_TOKEN_CONTRACT = "carin-token";
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    standardPrincipalCV,
+    noneCV,
+    someCV,
+    bufferCV,
+} from "@stacks/transactions";
 
-export const REWARDS_TOKEN_ADDRESSES = {
-  testnet: process.env.NEXT_PUBLIC_STACKS_REWARDS_TOKEN_ADDRESS_TESTNET || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
-  mainnet: process.env.NEXT_PUBLIC_STACKS_REWARDS_TOKEN_ADDRESS_MAINNET || ""
-};
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapResponse } from "./codec";
 
 export interface TokenMetadata {
-  name: string;
-  symbol: string;
-  decimals: number;
-  totalSupply: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    totalSupply: bigint;
+}
+
+const REF = () => getContractRef("carinRewardsToken");
+
+export async function getBalance(
+    address: string,
+    senderAddress?: string,
+): Promise<bigint> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-balance",
+        functionArgs: [standardPrincipalCV(address)],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    return BigInt(unwrapResponse<bigint | number | string>(result));
+}
+
+export async function getTotalSupply(senderAddress?: string): Promise<bigint> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-total-supply",
+        functionArgs: [],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    return BigInt(unwrapResponse<bigint | number | string>(result));
+}
+
+export async function getTokenMetadata(senderAddress?: string): Promise<TokenMetadata> {
+    const sender = senderAddress ?? getDeployerAddress();
+    const [name, symbol, decimals, totalSupply] = await Promise.all([
+        fetchCallReadOnlyFunction({
+            ...REF(),
+            functionName: "get-name",
+            functionArgs: [],
+            network: getStacksNetwork(),
+            senderAddress: sender,
+        }).then((r) => String(unwrapResponse<string>(r))),
+        fetchCallReadOnlyFunction({
+            ...REF(),
+            functionName: "get-symbol",
+            functionArgs: [],
+            network: getStacksNetwork(),
+            senderAddress: sender,
+        }).then((r) => String(unwrapResponse<string>(r))),
+        fetchCallReadOnlyFunction({
+            ...REF(),
+            functionName: "get-decimals",
+            functionArgs: [],
+            network: getStacksNetwork(),
+            senderAddress: sender,
+        }).then((r) => Number(unwrapResponse<number | bigint>(r))),
+        getTotalSupply(sender),
+    ]);
+    return { name, symbol, decimals, totalSupply };
+}
+
+export function buildTransferCall(args: {
+    amount: bigint | number | string;
+    senderAddress: string;
+    recipientAddress: string;
+    memo?: Uint8Array; // (optional (buff 34))
+}) {
+    return {
+        ...REF(),
+        functionName: "transfer",
+        functionArgs: [
+            uintCV(BigInt(args.amount)),
+            standardPrincipalCV(args.senderAddress),
+            standardPrincipalCV(args.recipientAddress),
+            args.memo ? someCV(bufferCV(args.memo)) : noneCV(),
+        ],
+        network: getStacksNetwork(),
+    };
 }

--- a/frontend/lib/contracts/spotReviews.ts
+++ b/frontend/lib/contracts/spotReviews.ts
@@ -1,0 +1,101 @@
+/**
+ * Typed surface for the `spot-reviews` Clarity contract.
+ */
+
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    stringUtf8CV,
+} from "@stacks/transactions";
+
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapOptionalTuple } from "./codec";
+
+export interface ReviewRecord {
+    id: number;
+    bookingId: number;
+    reviewer: string;
+    spotId: number;
+    rating: number;
+    comment: string;
+}
+
+export interface SpotRatingRecord {
+    spotId: number;
+    totalRating: number;
+    reviewCount: number;
+    /** Average × 10 (e.g. 45 = 4.5). The Clarity contract scales by 10. */
+    averageScaledByTen: number;
+    /** Convenience: the average as a normal decimal (e.g. 4.5). */
+    average: number;
+}
+
+const REF = () => getContractRef("spotReviews");
+
+export async function getReview(
+    reviewId: number | bigint,
+    senderAddress?: string,
+): Promise<ReviewRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-review",
+        functionArgs: [uintCV(BigInt(reviewId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+    return {
+        id: Number(reviewId),
+        bookingId: Number(tuple["booking-id"]),
+        reviewer: String(tuple["reviewer"]),
+        spotId: Number(tuple["spot-id"]),
+        rating: Number(tuple["rating"]),
+        comment: String(tuple["comment"]),
+    };
+}
+
+export async function getSpotRating(
+    spotId: number | bigint,
+    senderAddress?: string,
+): Promise<SpotRatingRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-spot-rating",
+        functionArgs: [uintCV(BigInt(spotId))],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+    const scaled = Number(tuple["average"]);
+    return {
+        spotId: Number(spotId),
+        totalRating: Number(tuple["total-rating"]),
+        reviewCount: Number(tuple["review-count"]),
+        averageScaledByTen: scaled,
+        average: scaled / 10,
+    };
+}
+
+export function buildSubmitReviewCall(args: {
+    bookingId: number | bigint;
+    spotId: number | bigint;
+    rating: number; // 1..5, enforced on chain
+    comment: string;
+}) {
+    if (args.rating < 1 || args.rating > 5 || !Number.isInteger(args.rating)) {
+        throw new Error(`rating must be an integer 1..5, got ${args.rating}`);
+    }
+    return {
+        ...REF(),
+        functionName: "submit-review",
+        functionArgs: [
+            uintCV(BigInt(args.bookingId)),
+            uintCV(BigInt(args.spotId)),
+            uintCV(BigInt(args.rating)),
+            stringUtf8CV(args.comment),
+        ],
+        network: getStacksNetwork(),
+    };
+}

--- a/frontend/lib/contracts/userRegistry.ts
+++ b/frontend/lib/contracts/userRegistry.ts
@@ -1,0 +1,108 @@
+/**
+ * Typed surface for the `user-registry` Clarity contract.
+ */
+
+import {
+    fetchCallReadOnlyFunction,
+    uintCV,
+    boolCV,
+    standardPrincipalCV,
+} from "@stacks/transactions";
+
+import { getStacksNetwork, getContractRef, getDeployerAddress } from "./network";
+import { unwrapOptionalTuple } from "./codec";
+
+export interface UserRecord {
+    address: string;
+    isVerified: boolean;
+    totalBookings: number;
+    /** Scaled by 10 (e.g. 45 = 4.5). */
+    hostRatingScaledByTen: number;
+    /** Decimal convenience. */
+    hostRating: number;
+    /** Scaled by 10. */
+    renterRatingScaledByTen: number;
+    renterRating: number;
+    totalHostReviews: number;
+    totalRenterReviews: number;
+}
+
+const REF = () => getContractRef("userRegistry");
+
+export async function getUser(
+    address: string,
+    senderAddress?: string,
+): Promise<UserRecord | null> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "get-user",
+        functionArgs: [standardPrincipalCV(address)],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    const tuple = unwrapOptionalTuple(result);
+    if (!tuple) return null;
+    const hostScaled = Number(tuple["host-rating"]);
+    const renterScaled = Number(tuple["renter-rating"]);
+    return {
+        address,
+        isVerified: Boolean(tuple["is-verified"]),
+        totalBookings: Number(tuple["total-bookings"]),
+        hostRatingScaledByTen: hostScaled,
+        hostRating: hostScaled / 10,
+        renterRatingScaledByTen: renterScaled,
+        renterRating: renterScaled / 10,
+        totalHostReviews: Number(tuple["total-host-reviews"]),
+        totalRenterReviews: Number(tuple["total-renter-reviews"]),
+    };
+}
+
+export async function isUserVerified(
+    address: string,
+    senderAddress?: string,
+): Promise<boolean> {
+    const result = await fetchCallReadOnlyFunction({
+        ...REF(),
+        functionName: "is-user-verified",
+        functionArgs: [standardPrincipalCV(address)],
+        network: getStacksNetwork(),
+        senderAddress: senderAddress ?? getDeployerAddress(),
+    });
+    // is-user-verified returns a bare bool, not optional.
+    return result.type === "true";
+}
+
+export function buildRegisterUserCall() {
+    return {
+        ...REF(),
+        functionName: "register-user",
+        functionArgs: [],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildVerifyUserCall(address: string) {
+    return {
+        ...REF(),
+        functionName: "verify-user",
+        functionArgs: [standardPrincipalCV(address)],
+        network: getStacksNetwork(),
+    };
+}
+
+export function buildUpdateRatingCall(args: {
+    userAddress: string;
+    isHost: boolean;
+    newRating: number; // 1..5
+}) {
+    return {
+        ...REF(),
+        functionName: "update-rating",
+        functionArgs: [
+            standardPrincipalCV(args.userAddress),
+            boolCV(args.isHost),
+            uintCV(BigInt(args.newRating)),
+        ],
+        network: getStacksNetwork(),
+    };
+}

--- a/frontend/lib/hooks/useParkingSpots.ts
+++ b/frontend/lib/hooks/useParkingSpots.ts
@@ -1,133 +1,119 @@
 /**
- * Hook to fetch and cache parking spots for map display
+ * Hook to fetch and cache parking spots from the on-chain
+ * parking-spot contract for map display.
+ *
+ * The Clarity contract doesn't expose a "list all spots" function,
+ * so we discover spots by walking ids from 1 until we hit a gap.
+ * This is reasonable for a few hundred listings; if the catalogue
+ * ever gets larger we'll need an off-chain indexer.
  */
 
-import { useState, useEffect, useCallback } from 'react';
-import { useParkingSpot } from './useParkingSpot';
+import { useState, useEffect, useCallback } from "react";
+
+import { getSpot, type ParkingSpotRecord } from "@/lib/contracts/parkingSpot";
 
 export interface ParkingSpot {
-  id: number;
-  location: string;
-  coordinates?: {
-    lat: number;
-    lng: number;
-  };
-  pricePerHour: string;
-  isAvailable: boolean;
-  owner: string;
-  images: string[];
-  description?: string;
-  totalBookings?: number;
+    id: number;
+    location: string;
+    coordinates?: { lat: number; lng: number };
+    pricePerHour: string;
+    isAvailable: boolean;
+    owner: string;
+    images: string[];
+    description?: string;
+    totalBookings?: number;
 }
 
 interface UseParkingSpotsState {
-  spots: ParkingSpot[];
-  loading: boolean;
-  error: string | null;
-  lastFetch: number | null;
+    spots: ParkingSpot[];
+    loading: boolean;
+    error: string | null;
+    lastFetch: number | null;
 }
 
-const CACHE_DURATION = 30000; // 30 seconds cache
+const CACHE_DURATION = 30_000; // 30s
+const MAX_SCAN = 200; // safety cap on the sequential walk
+const GAP_LIMIT = 5;  // stop after this many consecutive misses
+
+function toUiSpot(record: ParkingSpotRecord): ParkingSpot {
+    return {
+        id: record.id,
+        location: record.location,
+        // FIXME: location → coordinates needs a geocoding step. Until
+        // MapPicker writes lat/lng on chain (or we add an off-chain
+        // index), the map falls back to listing-only rendering.
+        coordinates: undefined,
+        pricePerHour: record.pricePerHour,
+        isAvailable: record.isAvailable,
+        owner: record.owner,
+        images: [],
+        description: undefined,
+        totalBookings: undefined,
+    };
+}
+
+async function discoverSpots(): Promise<ParkingSpot[]> {
+    const spots: ParkingSpot[] = [];
+    let consecutiveMisses = 0;
+
+    for (let id = 1; id <= MAX_SCAN; id++) {
+        const record = await getSpot(id);
+        if (record) {
+            spots.push(toUiSpot(record));
+            consecutiveMisses = 0;
+        } else if (++consecutiveMisses >= GAP_LIMIT) {
+            break;
+        }
+    }
+    return spots;
+}
 
 export function useParkingSpots() {
-  const [state, setState] = useState<UseParkingSpotsState>({
-    spots: [],
-    loading: false,
-    error: null,
-    lastFetch: null,
-  });
-
-  const fetchSpots = useCallback(async () => {
-    setState(prev => ({ ...prev, loading: true, error: null }));
-
-    try {
-      // TODO: Integrate with ParkingSpot smart contract
-      // For now, use mock data with coordinates
-      const mockSpots: ParkingSpot[] = [
-        {
-          id: 1,
-          location: '123 Main St, San Francisco, CA',
-          coordinates: { lat: 37.7749, lng: -122.4194 },
-          pricePerHour: '2.50',
-          isAvailable: true,
-          owner: 'SP2MF04VAGYHGAZWGTEDW5VYCPDWWSY08Z1QFNDSN',
-          images: [],
-          description: 'Convenient street parking near downtown',
-        },
-        {
-          id: 2,
-          location: '456 Market St, San Francisco, CA',
-          coordinates: { lat: 37.7849, lng: -122.4094 },
-          pricePerHour: '3.00',
-          isAvailable: true,
-          owner: 'SP123...',
-          images: [],
-          description: 'Premium parking spot in financial district',
-        },
-        {
-          id: 3,
-          location: '789 Mission St, San Francisco, CA',
-          coordinates: { lat: 37.7649, lng: -122.4294 },
-          pricePerHour: '1.75',
-          isAvailable: false,
-          owner: 'SP789...',
-          images: [],
-          description: 'Affordable parking option',
-        },
-      ];
-
-      // Simulate API delay
-      await new Promise(resolve => setTimeout(resolve, 500));
-
-      setState({
-        spots: mockSpots,
+    const [state, setState] = useState<UseParkingSpotsState>({
+        spots: [],
         loading: false,
         error: null,
-        lastFetch: Date.now(),
-      });
-    } catch (err: any) {
-      setState(prev => ({
-        ...prev,
-        loading: false,
-        error: err.message || 'Failed to fetch parking spots',
-      }));
-    }
-  }, []);
+        lastFetch: null,
+    });
 
-  const refreshSpots = useCallback(() => {
-    fetchSpots();
-  }, [fetchSpots]);
-
-  useEffect(() => {
-    fetchSpots();
-  }, [fetchSpots]);
-
-  const shouldRefresh = useCallback(() => {
-    if (!state.lastFetch) return true;
-    return Date.now() - state.lastFetch > CACHE_DURATION;
-  }, [state.lastFetch]);
-
-  useEffect(() => {
-    // Auto-refresh when cache expires
-    if (shouldRefresh() && !state.loading) {
-      const interval = setInterval(() => {
-        if (shouldRefresh()) {
-          fetchSpots();
+    const fetchSpots = useCallback(async () => {
+        setState((prev) => ({ ...prev, loading: true, error: null }));
+        try {
+            const spots = await discoverSpots();
+            setState({ spots, loading: false, error: null, lastFetch: Date.now() });
+        } catch (err: unknown) {
+            const message =
+                err instanceof Error ? err.message : "Failed to fetch parking spots";
+            setState((prev) => ({ ...prev, loading: false, error: message }));
         }
-      }, CACHE_DURATION);
+    }, []);
 
-      return () => clearInterval(interval);
-    }
-  }, [shouldRefresh, state.loading, fetchSpots]);
+    const refreshSpots = useCallback(() => {
+        fetchSpots();
+    }, [fetchSpots]);
 
-  return {
-    spots: state.spots,
-    loading: state.loading,
-    error: state.error,
-    refresh: refreshSpots,
-  };
+    useEffect(() => {
+        fetchSpots();
+    }, [fetchSpots]);
+
+    const shouldRefresh = useCallback(() => {
+        if (!state.lastFetch) return true;
+        return Date.now() - state.lastFetch > CACHE_DURATION;
+    }, [state.lastFetch]);
+
+    useEffect(() => {
+        if (shouldRefresh() && !state.loading) {
+            const interval = setInterval(() => {
+                if (shouldRefresh()) fetchSpots();
+            }, CACHE_DURATION);
+            return () => clearInterval(interval);
+        }
+    }, [shouldRefresh, state.loading, fetchSpots]);
+
+    return {
+        spots: state.spots,
+        loading: state.loading,
+        error: state.error,
+        refresh: refreshSpots,
+    };
 }
-
-
-
-

--- a/frontend/lib/hooks/useSpotDetails.ts
+++ b/frontend/lib/hooks/useSpotDetails.ts
@@ -1,65 +1,88 @@
 import { useState, useEffect, useCallback } from "react";
 
+import { getSpot } from "@/lib/contracts/parkingSpot";
+import { getSpotRating } from "@/lib/contracts/spotReviews";
+
 interface SpotDetails {
-  id: string;
-  location: string;
-  pricePerHour: string;
-  images: string[];
-  description: string;
-  owner: string;
-  isAvailable: boolean;
-  totalBookings: number;
-  rating?: number;
+    id: string;
+    location: string;
+    pricePerHour: string;
+    images: string[];
+    description: string;
+    owner: string;
+    isAvailable: boolean;
+    totalBookings: number;
+    rating?: number;
+}
+
+function parseSpotId(spotId: string): number | null {
+    const n = Number(spotId);
+    return Number.isFinite(n) && Number.isInteger(n) && n > 0 ? n : null;
 }
 
 export function useSpotDetails(spotId: string) {
-  const [spot, setSpot] = useState<SpotDetails | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+    const [spot, setSpot] = useState<SpotDetails | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
-  const fetchSpotDetails = useCallback(async () => {
-    if (!spotId) return;
+    const fetchSpotDetails = useCallback(async () => {
+        if (!spotId) return;
+        const id = parseSpotId(spotId);
+        if (id === null) {
+            setError(`invalid spot id: ${spotId}`);
+            setLoading(false);
+            return;
+        }
 
-    setLoading(true);
-    setError(null);
+        setLoading(true);
+        setError(null);
 
-    try {
-      // TODO: Fetch from ParkingSpot smart contract
-      // const contract = getParkingSpotContract();
-      // const spotData = await contract.getSpot(spotId);
-      
-      // Mock implementation
-      await new Promise(resolve => setTimeout(resolve, 500));
-      const mockSpot: SpotDetails = {
-        id: spotId,
-        location: "123 Main St, San Francisco, CA",
-        pricePerHour: "2.50",
-        images: ["QmExample1"],
-        description: "Convenient street parking",
-        owner: "0x123...",
-        isAvailable: true,
-        totalBookings: 45,
-      };
-      setSpot(mockSpot);
-    } catch (err: any) {
-      setError(err.message || "Failed to fetch spot details");
-    } finally {
-      setLoading(false);
-    }
-  }, [spotId]);
+        try {
+            const [record, rating] = await Promise.all([
+                getSpot(id),
+                // get-spot-rating returns null for spots with no reviews — that's fine.
+                getSpotRating(id).catch(() => null),
+            ]);
 
-  useEffect(() => {
-    fetchSpotDetails();
-  }, [fetchSpotDetails]);
+            if (!record) {
+                setSpot(null);
+                setError(`spot ${spotId} not found`);
+                return;
+            }
 
-  return {
-    spot,
-    loading,
-    error,
-    refresh: fetchSpotDetails,
-  };
+            setSpot({
+                id: spotId,
+                location: record.location,
+                pricePerHour: record.pricePerHour,
+                // FIXME: images and description aren't part of the on-chain
+                // record — they should come from an IPFS CID stored alongside
+                // the spot. See PR 5 for the upload flow.
+                images: [],
+                description: "",
+                owner: record.owner,
+                isAvailable: record.isAvailable,
+                // FIXME: total bookings isn't a read on parking-spot. We can
+                // derive it by getting the booking ids from
+                // booking.get-spot-bookings and counting, but skipping for
+                // now to keep this hook's blast radius small.
+                totalBookings: 0,
+                rating: rating?.average,
+            });
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : "Failed to fetch spot details");
+        } finally {
+            setLoading(false);
+        }
+    }, [spotId]);
+
+    useEffect(() => {
+        fetchSpotDetails();
+    }, [fetchSpotDetails]);
+
+    return {
+        spot,
+        loading,
+        error,
+        refresh: fetchSpotDetails,
+    };
 }
-
-
-
-

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@stacks/connect": "latest",
+        "@stacks/network": "^7.3.1",
+        "@stacks/transactions": "^7.4.0",
         "@types/leaflet": "^1.9.21",
         "@types/leaflet.markercluster": "^1.5.6",
         "date-fns": "^2.30.0",
@@ -17,7 +19,6 @@
         "leaflet.markercluster": "^1.5.3",
         "next": "^14.0.0",
         "pino-pretty": "^13.1.3",
-        "porto": "^0.2.37",
         "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
         "react-datepicker": "^4.25.0",
@@ -2294,9 +2295,9 @@
       }
     },
     "node_modules/@stacks/transactions": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.3.1.tgz",
-      "integrity": "sha512-ufnC1BPrOKz5b5gxxdseP3vBrFq1+qx1L6t+J/QnjXULyWdkhtS+LBEqRw2bL5qNteMvU2GhqPgFtYQPzolGbw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
+      "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",
@@ -2557,14 +2558,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5661,7 +5662,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7555,15 +7556,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9357,26 +9349,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mipd": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mipd/-/mipd-0.0.7.tgz",
-      "integrity": "sha512-aAPZPNDQ3uMTdKbuO2YmAw2TxLHO0moa4YKAyETM/DTj5FloZo+a+8tU+iv4GmW+sOxKLSRwcSFuczk+Cpt6fg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9861,63 +9833,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ox": {
-      "version": "0.9.17",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.17.tgz",
-      "integrity": "sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.9",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ox/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10266,99 +10181,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/porto": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.37.tgz",
-      "integrity": "sha512-l3IOUvf5O9rM82VW7v/R5Y2X2niU1kmfXMYYPr/VLMvtKKySr7PiAO3TXWjGft5PV17800VnMCmEaRuxA+N4ug==",
-      "license": "MIT",
-      "dependencies": {
-        "hono": "^4.10.3",
-        "idb-keyval": "^6.2.1",
-        "mipd": "^0.0.7",
-        "ox": "^0.9.6",
-        "zod": "^4.1.5",
-        "zustand": "^5.0.1"
-      },
-      "bin": {
-        "porto": "dist/cli/bin/index.js"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": ">=5.59.0",
-        "@wagmi/core": ">=2.16.3",
-        "expo-auth-session": ">=7.0.8",
-        "expo-crypto": ">=15.0.7",
-        "expo-web-browser": ">=15.0.8",
-        "react": ">=18",
-        "react-native": ">=0.81.4",
-        "typescript": ">=5.4.0",
-        "viem": ">=2.37.0",
-        "wagmi": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@tanstack/react-query": {
-          "optional": true
-        },
-        "expo-auth-session": {
-          "optional": true
-        },
-        "expo-crypto": {
-          "optional": true
-        },
-        "expo-web-browser": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "wagmi": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/porto/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/porto/node_modules/zustand": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
-      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -12582,7 +12404,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@stacks/connect": "latest",
+    "@stacks/network": "^7.3.1",
+    "@stacks/transactions": "^7.4.0",
     "@types/leaflet": "^1.9.21",
     "@types/leaflet.markercluster": "^1.5.6",
     "date-fns": "^2.30.0",


### PR DESCRIPTION
## Summary

**Scope: plumbing only.** Lays down the typed surface the frontend needs to talk to the deployed Clarity contracts, and wires two read-only hooks (\`useParkingSpots\`, \`useSpotDetails\`) end-to-end as worked examples. The remaining TODOs across booking, owner dashboard, disputes, and rewards keep their TODO comments — they now have a real typed surface to call into.

**Cannot browser-test from this branch.** Every commit type-checks (\`tsc --noEmit\`), but the read-only calls have not been exercised against a deployed contract. Set \`NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS\` to a real deployer address and load the map / spot detail page to validate.

## What's in here (10 commits)

| # | Commit |
|---|---|
| 1 | \`feat(config)\`: unify Stacks network and contract-address config (\`NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS\` + \`NEXT_PUBLIC_STACKS_NETWORK\`) |
| 2 | \`feat(contracts)\`: Clarity value codec helpers (\`unwrapResponse\`, \`unwrapOptionalTuple\`, microSTX ↔ STX) |
| 3 | \`feat(contracts)\`: real parking-spot read/write surface |
| 4 | \`feat(contracts)\`: real booking read/write surface |
| 5 | \`feat(contracts)\`: real payment-escrow + dispute-resolution surfaces |
| 6 | \`feat(contracts)\`: real spot-reviews surface |
| 7 | \`feat(contracts)\`: real user-registry + car-registry surfaces |
| 8 | \`feat(contracts)\`: real rewards token + manager surfaces |
| 9 | \`feat(hooks)\`: wire \`useParkingSpots\` to real on-chain reads |
| 10 | \`feat(hooks)\`: wire \`useSpotDetails\` to real on-chain reads |

## Design notes

- **Single source of truth for contract addresses.** \`frontend/lib/contracts/network.ts\` reads \`NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS\` (deployer) and \`NEXT_PUBLIC_STACKS_NETWORK\` (mainnet/testnet/devnet). The old \`constants/contracts.ts\`, \`lib/config/contracts.ts\`, and per-file \`*_ADDRESSES_TESTNET\` env vars are kept as deprecated re-exports so nothing breaks during migration.
- **Reads are wired; writes return request objects.** Each contract module exposes \`getX\` for reads (returns plain JS or null/throws) and \`buildXCall\` for writes (returns an object the caller hands to \`@stacks/connect\`'s \`openContractCall\`). This keeps the wallet boundary explicit and the modules easy to unit-test.
- **Two contract bugs from PR 3 are not addressed here.** \`buildClaimRewardsCall\` and the legacy dispute types have inline comments pointing back at the test pins from PR 3 (#38).
- **Spot discovery walks ids 1..N.** The Clarity contract has no "list all spots" call; \`discoverSpots\` walks sequentially with \`MAX_SCAN=200\` and \`GAP_LIMIT=5\`. Fine for the current size; if the catalog grows we need an off-chain indexer.
- **\`images\` / \`description\` / \`totalBookings\` on \`useSpotDetails\` are left as FIXMEs.** Images need PR 5 (IPFS); totalBookings needs a small \`booking.get-spot-bookings\` count and can land in a follow-up.

## Remaining TODOs (intentional — out of scope)

| File | Why deferred |
|---|---|
| \`components/owner/EditSpotModal.tsx\` | update-spot call ready in \`parkingSpot.buildUpdateAvailabilityCall\`; UI wiring left for follow-up |
| \`components/owner/ListSpotForm.tsx\` | same — \`buildListSpotCall\` ready |
| \`components/owner/SpotsList.tsx\` | needs owner-cars query; the typed call is ready |
| \`components/owner/EarningsSummary.tsx\` | needs aggregate of \`getEscrow\` across owner's escrows |
| \`components/booking/BookingFlow.tsx\` | needs \`buildCreateBookingCall\` + tx prompt via \`@stacks/connect\` |
| \`lib/hooks/useBookingHistory.ts\` | walks bookings — same pattern as \`discoverSpots\` |
| \`lib/hooks/useBookingTransaction.ts\` | needs the \`openContractCall\` plumbing |
| \`lib/hooks/useSpotAvailability.ts\` | derive from \`getSpot().isAvailable\` |
| \`app/api/ipfs/upload/route.ts\`, \`lib/ipfs.ts\`, \`lib/utils/evidenceHandler.ts\` | covered by PR 5 |

## Test plan

- [ ] \`cd frontend && npm ci && npx tsc --noEmit\` passes
- [ ] \`npm run build\` succeeds
- [ ] Set \`NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS\` to a deployed address; load the map page and verify spots render
- [ ] Load \`/spots/[id]\` for a known spot id and verify the detail card pulls real on-chain data

🤖 Generated with [Claude Code](https://claude.com/claude-code)