### PR TITLE
feat(ipfs): real Pinata-backed uploads, validation, and gateway helpers

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,15 +1,25 @@
-# WalletConnect / Reown AppKit Configuration
-NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_walletconnect_project_id_here
+# ---------------------------------------------------------------------------
+# Stacks network + CarIn contract address
+# ---------------------------------------------------------------------------
 
-# Celo Network Configuration
-NEXT_PUBLIC_CELO_RPC_URL=https://alfajores-forno.celo-testnet.org
-NEXT_PUBLIC_CELO_MAINNET_Rorg
+# Which Stacks network the app talks to.
+# Allowed values: mainnet | testnet | devnet
+NEXT_PUBLIC_STACKS_NETWORK=testnet
 
-# Contract Addresses (update after deployment)
-NEXT_PUBLIC_PARKING_SPOT_CONTRACT_ADDRESS=
-NEXT_PUBLIC_PAYMENT_ESCROW_CONTRACT_ADDRESS=
+# Deployer address of the CarIn Clarity contracts. The contract names
+# themselves are constants in lib/contracts/network.ts.
+NEXT_PUBLIC_STACKS_CONTRACT_ADDRESS=
 
-# IPFS Configuration (optional)
-NEXT_PUBLIC_IPFS_GATEWAY=https://ipfs.io/ipfs/
-NEXT_PUBLIC_PINATA_JWT=
-NEXT_PUBLIC_NFT_STORAGE_TOKEN=
+# ---------------------------------------------------------------------------
+# IPFS (Pinata)
+# ---------------------------------------------------------------------------
+
+# Server-side Pinata JWT used by /api/ipfs/upload and
+# /api/ipfs/upload-json. MUST NOT be prefixed with NEXT_PUBLIC_ —
+# anything with that prefix ships in the browser bundle.
+PINATA_JWT=
+
+# Public IPFS gateway used to render pinned content. Defaults to
+# Pinata's dedicated gateway. Override if you have your own gateway
+# or want to use a different public one (e.g. https://ipfs.io).
+NEXT_PUBLIC_IPFS_GATEWAY=https://gateway.pinata.cloud

--- a/frontend/app/api/ipfs/upload-json/route.ts
+++ b/frontend/app/api/ipfs/upload-json/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { pinJson, PinataConfigError, PinataUploadError } from "@/lib/ipfs/pinata";
+
+/**
+ * POST /api/ipfs/upload-json
+ * application/json body. The whole body is pinned as the IPFS object.
+ *
+ * Returns: { cid, pinSize, pinnedAt, url } on success.
+ *
+ * Used for structured metadata (e.g. a spot description object,
+ * dispute evidence summary). For raw files, use /api/ipfs/upload.
+ */
+export async function POST(request: NextRequest) {
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: "expected a JSON body" }, { status: 400 });
+    }
+    if (body === null || typeof body !== "object") {
+        return NextResponse.json(
+            { error: "body must be a JSON object" },
+            { status: 400 },
+        );
+    }
+
+    // Reasonable cap so a single pinJSON request can't hold the
+    // route handler open with a 50 MB payload.
+    const serialized = JSON.stringify(body);
+    if (serialized.length > 1_000_000) {
+        return NextResponse.json(
+            { error: "JSON payload exceeds 1 MB limit" },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const result = await pinJson(body);
+        const gateway =
+            process.env.NEXT_PUBLIC_IPFS_GATEWAY ?? "https://gateway.pinata.cloud";
+        return NextResponse.json({
+            ...result,
+            url: `${gateway}/ipfs/${result.cid}`,
+        });
+    } catch (err: unknown) {
+        if (err instanceof PinataConfigError) {
+            return NextResponse.json({ error: err.message }, { status: 500 });
+        }
+        if (err instanceof PinataUploadError) {
+            return NextResponse.json(
+                { error: err.message },
+                { status: err.status ?? 502 },
+            );
+        }
+        const message = err instanceof Error ? err.message : "unknown upload error";
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/frontend/app/api/ipfs/upload/route.ts
+++ b/frontend/app/api/ipfs/upload/route.ts
@@ -1,64 +1,60 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
+
+import { pinFile, PinataConfigError, PinataUploadError } from "@/lib/ipfs/pinata";
+import { validateEvidenceUpload } from "@/lib/ipfs/validation";
 
 /**
- * API route for uploading files to IPFS
- * This is a placeholder - implement with actual IPFS service (Pinata, Infura, etc.)
+ * POST /api/ipfs/upload
+ * multipart/form-data with a single "file" field.
+ *
+ * Returns: { cid, pinSize, pinnedAt, url } on success.
+ *
+ * Validates against `validateEvidenceUpload` (a superset of image
+ * types, since the same endpoint serves both spot photos and
+ * dispute evidence). The same validator is used in the picker so
+ * the limits stay in sync.
  */
 export async function POST(request: NextRequest) {
-  try {
-    const formData = await request.formData();
-    const file = formData.get('file') as File;
-
-    if (!file) {
-      return NextResponse.json(
-        { error: 'No file provided' },
-        { status: 400 }
-      );
+    let formData: FormData;
+    try {
+        formData = await request.formData();
+    } catch {
+        return NextResponse.json({ error: "expected multipart/form-data" }, { status: 400 });
     }
 
-    // Validate file size (max 10MB)
-    const maxSize = 10 * 1024 * 1024;
-    if (file.size > maxSize) {
-      return NextResponse.json(
-        { error: 'File size exceeds 10MB limit' },
-        { status: 400 }
-      );
+    const file = formData.get("file");
+    if (!(file instanceof File)) {
+        return NextResponse.json({ error: "missing or non-file 'file' field" }, { status: 400 });
     }
 
-    // TODO: Implement actual IPFS upload
-    // Example using Pinata:
-    /*
-    const pinataApiKey = process.env.PINATA_API_KEY;
-    const pinataSecretKey = process.env.PINATA_SECRET_KEY;
-    
-    const formData = new FormData();
-    formData.append('file', file);
+    const validation = validateEvidenceUpload(file);
+    if (!validation.ok) {
+        return NextResponse.json({ error: validation.reason }, { status: 400 });
+    }
 
-    const response = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
-      method: 'POST',
-      headers: {
-        'pinata_api_key': pinataApiKey,
-        'pinata_secret_api_key': pinataSecretKey,
-      },
-      body: formData,
-    });
-
-    const data = await response.json();
-    return NextResponse.json({ hash: data.IpfsHash });
-    */
-
-    // Placeholder response
-    const mockHash = 'Qm' + Buffer.from(file.name + Date.now()).toString('base64').slice(0, 42);
-    return NextResponse.json({ hash: mockHash });
-  } catch (error: any) {
-    console.error('IPFS upload error:', error);
-    return NextResponse.json(
-      { error: error.message || 'Failed to upload to IPFS' },
-      { status: 500 }
-    );
-  }
+    try {
+        const result = await pinFile(file, file.name);
+        const gateway = gatewayBase();
+        return NextResponse.json({
+            ...result,
+            url: `${gateway}/ipfs/${result.cid}`,
+        });
+    } catch (err: unknown) {
+        if (err instanceof PinataConfigError) {
+            // 500 (not 400) — this is a server misconfiguration, not a bad client request.
+            return NextResponse.json({ error: err.message }, { status: 500 });
+        }
+        if (err instanceof PinataUploadError) {
+            return NextResponse.json(
+                { error: err.message },
+                { status: err.status ?? 502 },
+            );
+        }
+        const message = err instanceof Error ? err.message : "unknown upload error";
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
 }
 
-
-
-
+function gatewayBase(): string {
+    return process.env.NEXT_PUBLIC_IPFS_GATEWAY ?? "https://gateway.pinata.cloud";
+}

--- a/frontend/components/owner/ImageUpload.tsx
+++ b/frontend/components/owner/ImageUpload.tsx
@@ -3,95 +3,101 @@
 import { useState } from "react";
 import Image from "next/image";
 
+import { uploadImageToIPFS, IPFSValidationError, IPFSUploadError } from "@/lib/ipfs";
+import { validateImageUpload } from "@/lib/ipfs/validation";
+
 interface ImageUploadProps {
-  onImageUploaded: (ipfsHash: string) => void;
+    onImageUploaded: (ipfsHash: string) => void;
 }
 
 export default function ImageUpload({ onImageUploaded }: ImageUploadProps) {
-  const [isUploading, setIsUploading] = useState(false);
-  const [preview, setPreview] = useState<string | null>(null);
+    const [isUploading, setIsUploading] = useState(false);
+    const [preview, setPreview] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
 
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
 
-    // Validate file type
-    if (!file.type.startsWith("image/")) {
-      alert("Please select an image file");
-      return;
-    }
+        // Pre-validate so the user sees the error before the round-trip.
+        const validation = validateImageUpload(file);
+        if (!validation.ok) {
+            setError(validation.reason);
+            e.target.value = "";
+            return;
+        }
 
-    // Create preview
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      setPreview(reader.result as string);
+        setError(null);
+
+        const reader = new FileReader();
+        reader.onloadend = () => {
+            setPreview(reader.result as string);
+        };
+        reader.readAsDataURL(file);
+
+        setIsUploading(true);
+        try {
+            const { hash } = await uploadImageToIPFS(file);
+            onImageUploaded(hash);
+            setPreview(null);
+            e.target.value = "";
+        } catch (err: unknown) {
+            const message =
+                err instanceof IPFSValidationError || err instanceof IPFSUploadError
+                    ? err.message
+                    : err instanceof Error
+                        ? err.message
+                        : "Failed to upload image";
+            setError(message);
+            console.error("IPFS upload failed:", err);
+        } finally {
+            setIsUploading(false);
+        }
     };
-    reader.readAsDataURL(file);
 
-    // Upload to IPFS
-    setIsUploading(true);
-    try {
-      // TODO: Integrate with IPFS service (Pinata, NFT.Storage, etc.)
-      // For now, simulate IPFS upload
-      await new Promise(resolve => setTimeout(resolve, 2000));
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center justify-center w-full">
+                <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100">
+                    <div className="flex flex-col items-center justify-center pt-5 pb-6">
+                        {isUploading ? (
+                            <div className="text-blue-600">Uploading to IPFS...</div>
+                        ) : (
+                            <>
+                                <svg className="w-10 h-10 mb-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                                </svg>
+                                <p className="mb-2 text-sm text-gray-500">
+                                    <span className="font-semibold">Click to upload</span> or drag and drop
+                                </p>
+                                <p className="text-xs text-gray-500">PNG, JPG, GIF, WebP up to 10MB</p>
+                            </>
+                        )}
+                    </div>
+                    <input
+                        type="file"
+                        className="hidden"
+                        accept="image/*"
+                        onChange={handleFileSelect}
+                        disabled={isUploading}
+                    />
+                </label>
+            </div>
 
-      const mockIpfsHash = `Qm${Math.random().toString(36).substring(2, 15)}${Math.random().toString(36).substring(2, 15)}`;
-      onImageUploaded(mockIpfsHash);
-
-      // Reset preview after upload
-      setPreview(null);
-      e.target.value = "";
-    } catch (error) {
-      console.error("Error uploading to IPFS:", error);
-      alert("Failed to upload image. Please try again.");
-    } finally {
-      setIsUploading(false);
-    }
-  };
-
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-center w-full">
-        <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100">
-          <div className="flex flex-col items-center justify-center pt-5 pb-6">
-            {isUploading ? (
-              <div className="text-blue-600">Uploading to IPFS...</div>
-            ) : (
-              <>
-                <svg className="w-10 h-10 mb-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-                </svg>
-                <p className="mb-2 text-sm text-gray-500">
-                  <span className="font-semibold">Click to upload</span> or drag and drop
-                </p>
-                <p className="text-xs text-gray-500">PNG, JPG, GIF up to 10MB</p>
-              </>
+            {error && (
+                <p className="text-sm text-red-500" role="alert">{error}</p>
             )}
-          </div>
-          <input
-            type="file"
-            className="hidden"
-            accept="image/*"
-            onChange={handleFileSelect}
-            disabled={isUploading}
-          />
-        </label>
-      </div>
 
-      {preview && (
-        <div className="mt-8 relative w-full aspect-video rounded-3xl overflow-hidden ring-1 ring-white/10 glass-card">
-          <Image
-            src={preview}
-            alt="Preview"
-            fill
-            className="object-cover"
-          />
+            {preview && (
+                <div className="mt-8 relative w-full aspect-video rounded-3xl overflow-hidden ring-1 ring-white/10 glass-card">
+                    <Image
+                        src={preview}
+                        alt="Preview"
+                        fill
+                        className="object-cover"
+                    />
+                </div>
+            )}
         </div>
-      )}
-    </div>
-  );
+    );
 }
-
-
-
-

--- a/frontend/lib/ipfs.ts
+++ b/frontend/lib/ipfs.ts
@@ -1,80 +1,129 @@
 /**
- * IPFS utility functions for uploading images and metadata
- * TODO: Integrate with IPFS service (Pinata, NFT.Storage, or custom IPFS node)
+ * Browser-side IPFS upload helpers.
+ *
+ * These hit the project's own API routes (`/api/ipfs/upload`,
+ * `/api/ipfs/upload-json`) which in turn pin to Pinata using a
+ * server-side JWT. The browser never sees PINATA_JWT.
+ *
+ * The gateway URL helper is extracted into lib/ipfs/gateway.ts
+ * in a follow-up commit and re-exported here.
  */
 
+import {
+    validateImageUpload,
+    validateEvidenceUpload,
+    type ValidationResult,
+} from "./ipfs/validation";
+
 export interface IPFSUploadResult {
-  hash: string;
-  url: string;
+    /** Raw IPFS CID (e.g. "bafy..." or "Qm..."). */
+    hash: string;
+    /** Convenience: full gateway URL pointing at the pinned content. */
+    url: string;
+    /** Bytes pinned, as reported by Pinata. */
+    pinSize?: number;
 }
 
+interface ApiPinResponse {
+    cid: string;
+    pinSize: number;
+    pinnedAt: string;
+    url: string;
+}
+
+interface ApiErrorResponse {
+    error: string;
+}
+
+export class IPFSValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "IPFSValidationError";
+    }
+}
+
+export class IPFSUploadError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+        super(message);
+        this.name = "IPFSUploadError";
+        this.status = status;
+    }
+}
+
+/**
+ * Upload a file (image, video, document) to IPFS via the project's
+ * `/api/ipfs/upload` route. Pre-validates against the shared
+ * evidence-upload rules so the user sees the error before a network
+ * round-trip.
+ */
 export async function uploadToIPFS(file: File): Promise<IPFSUploadResult> {
-  try {
-    // TODO: Implement actual IPFS upload
-    // Example with NFT.Storage:
-    // const client = new NFTStorage({ token: process.env.NEXT_PUBLIC_NFT_STORAGE_TOKEN });
-    // const blob = new Blob([file]);
-    // const cid = await client.storeBlob(blob);
-    
-    // Example with Pinata:
-    // const formData = new FormData();
-    // formData.append('file', file);
-    // const response = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
-    //   method: 'POST',
-    //   headers: { 'Authorization': `Bearer ${process.env.NEXT_PUBLIC_PINATA_JWT}` },
-    //   body: formData,
-    // });
-    // const data = await response.json();
-    
-    // Mock implementation for now
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    const mockHash = `Qm${Math.random().toString(36).substring(2, 15)}${Math.random().toString(36).substring(2, 15)}`;
-    const mockUrl = `https://ipfs.io/ipfs/${mockHash}`;
-    
-    return {
-      hash: mockHash,
-      url: mockUrl,
-    };
-  } catch (error) {
-    console.error("Error uploading to IPFS:", error);
-    throw new Error("Failed to upload to IPFS");
-  }
+    assertValid(validateEvidenceUpload(file));
+    return postFile("/api/ipfs/upload", file);
 }
 
-export async function uploadMetadataToIPFS(metadata: object): Promise<IPFSUploadResult> {
-  try {
-    // TODO: Implement actual IPFS metadata upload
-    // const client = new NFTStorage({ token: process.env.NEXT_PUBLIC_NFT_STORAGE_TOKEN });
-    // const metadataBlob = new Blob([JSON.stringify(metadata)]);
-    // const cid = await client.storeBlob(metadataBlob);
-    
-    // Mock implementation
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    const mockHash = `Qm${Math.random().toString(36).substring(2, 15)}${Math.random().toString(36).substring(2, 15)}`;
-    
-    return {
-      hash: mockHash,
-      url: `https://ipfs.io/ipfs/${mockHash}`,
-    };
-  } catch (error) {
-    console.error("Error uploading metadata to IPFS:", error);
-    throw new Error("Failed to upload metadata to IPFS");
-  }
+/**
+ * Image-only variant — tighter validation (no PDF, no video).
+ */
+export async function uploadImageToIPFS(file: File): Promise<IPFSUploadResult> {
+    assertValid(validateImageUpload(file));
+    return postFile("/api/ipfs/upload", file);
 }
 
+/**
+ * Pin a JSON object to IPFS as metadata.
+ */
+export async function uploadMetadataToIPFS(metadata: unknown): Promise<IPFSUploadResult> {
+    const res = await fetch("/api/ipfs/upload-json", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(metadata),
+    });
+    return toResult(await parseResponse(res));
+}
+
+/**
+ * Build a gateway URL for an existing CID. Kept here for
+ * backwards-compatibility with the previous module surface; a
+ * follow-up commit extracts the gateway logic into its own module
+ * and re-exports it from here.
+ */
 export function getIPFSGatewayURL(hash: string): string {
-  // Use multiple gateways for redundancy
-  const gateways = [
-    `https://ipfs.io/ipfs/${hash}`,
-    `https://gateway.pinata.cloud/ipfs/${hash}`,
-    `https://cloudflare-ipfs.com/ipfs/${hash}`,
-  ];
-  
-  return gateways[0]; // Return primary gateway
+    const base =
+        (typeof process !== "undefined"
+            ? process.env.NEXT_PUBLIC_IPFS_GATEWAY
+            : undefined) ?? "https://gateway.pinata.cloud";
+    return `${base.replace(/\/$/, "")}/ipfs/${hash}`;
 }
 
+// ---------------------------------------------------------------------------
 
+async function postFile(endpoint: string, file: File): Promise<IPFSUploadResult> {
+    const form = new FormData();
+    form.append("file", file);
 
+    const res = await fetch(endpoint, { method: "POST", body: form });
+    return toResult(await parseResponse(res));
+}
 
+function assertValid(result: ValidationResult): void {
+    if (!result.ok) throw new IPFSValidationError(result.reason);
+}
+
+async function parseResponse(res: Response): Promise<ApiPinResponse> {
+    if (!res.ok) {
+        let message = `IPFS upload failed (HTTP ${res.status})`;
+        try {
+            const body = (await res.json()) as ApiErrorResponse;
+            if (body?.error) message = body.error;
+        } catch {
+            // Body wasn't JSON; keep the generic message.
+        }
+        throw new IPFSUploadError(message, res.status);
+    }
+    return (await res.json()) as ApiPinResponse;
+}
+
+function toResult(data: ApiPinResponse): IPFSUploadResult {
+    return { hash: data.cid, url: data.url, pinSize: data.pinSize };
+}

--- a/frontend/lib/ipfs.ts
+++ b/frontend/lib/ipfs.ts
@@ -84,17 +84,11 @@ export async function uploadMetadataToIPFS(metadata: unknown): Promise<IPFSUploa
 
 /**
  * Build a gateway URL for an existing CID. Kept here for
- * backwards-compatibility with the previous module surface; a
- * follow-up commit extracts the gateway logic into its own module
- * and re-exports it from here.
+ * backwards-compatibility with the previous module surface; the
+ * implementation lives in lib/ipfs/gateway.ts.
  */
-export function getIPFSGatewayURL(hash: string): string {
-    const base =
-        (typeof process !== "undefined"
-            ? process.env.NEXT_PUBLIC_IPFS_GATEWAY
-            : undefined) ?? "https://gateway.pinata.cloud";
-    return `${base.replace(/\/$/, "")}/ipfs/${hash}`;
-}
+export { buildGatewayUrl as getIPFSGatewayURL } from "./ipfs/gateway";
+export { getFallbackGateways, normaliseCid } from "./ipfs/gateway";
 
 // ---------------------------------------------------------------------------
 

--- a/frontend/lib/ipfs/README.md
+++ b/frontend/lib/ipfs/README.md
@@ -1,0 +1,48 @@
+# lib/ipfs
+
+IPFS upload + gateway helpers for the CarIn frontend.
+
+## Surface
+
+| Module | Used from | What it does |
+| --- | --- | --- |
+| `pinata.ts` | server (Route Handlers only) | Pin a file or JSON object to Pinata using `PINATA_JWT`. |
+| `validation.ts` | both | Shared MIME / size rules (`validateImageUpload`, `validateEvidenceUpload`, `IPFS_LIMITS`). |
+| `gateway.ts` | both | Build gateway URLs (`buildGatewayUrl`, `getFallbackGateways`, `normaliseCid`). |
+| `../ipfs.ts` | browser | Thin wrapper around `/api/ipfs/upload[-json]`: `uploadToIPFS`, `uploadImageToIPFS`, `uploadMetadataToIPFS`. |
+
+## Configuration
+
+| Env var | Where it's read | Required |
+| --- | --- | --- |
+| `PINATA_JWT` | server only (`pinata.ts`) | Yes, for actual uploads. Server-side only — never `NEXT_PUBLIC_`. |
+| `NEXT_PUBLIC_IPFS_GATEWAY` | browser and server | No — defaults to `https://gateway.pinata.cloud`. |
+
+`PINATA_JWT` is obtained from the Pinata dashboard → API Keys → "New JWT". Anything from a free or paid Pinata account works.
+
+## Why a server route instead of calling Pinata from the browser?
+
+The Pinata JWT acts as a bearer token for the entire account. If we shipped it to the browser (via `NEXT_PUBLIC_…`), every visitor could pin arbitrary data and burn the storage quota. The Route Handlers under `app/api/ipfs/` hold the JWT and proxy the upload, so the credential stays on the server.
+
+## How uploads flow
+
+```
+ImageUpload.tsx
+  └─► lib/ipfs.ts: uploadImageToIPFS(file)
+        └─► validation.ts: validateImageUpload(file)
+        └─► fetch POST /api/ipfs/upload
+              └─► app/api/ipfs/upload/route.ts
+                    └─► validation.ts: validateEvidenceUpload(file)
+                    └─► pinata.ts: pinFile(file)
+                          └─► Pinata pinFileToIPFS
+```
+
+The validation step runs twice on purpose — client-side for UX, server-side as the source of truth.
+
+## Limits
+
+- 10 MB per file (`IPFS_LIMITS.maxFileBytes`)
+- 1 MB per JSON metadata pin (enforced in `/api/ipfs/upload-json`)
+- Allowed file types: JPEG, PNG, WebP, GIF, MP4, WebM, PDF
+
+Bump the constants in `validation.ts` (and the JSON cap in `upload-json/route.ts`) if you need different limits.

--- a/frontend/lib/ipfs/__tests__/gateway.test.ts
+++ b/frontend/lib/ipfs/__tests__/gateway.test.ts
@@ -1,0 +1,70 @@
+import { buildGatewayUrl, getFallbackGateways, normaliseCid } from "../gateway";
+
+describe("normaliseCid", () => {
+    it("strips the ipfs:// prefix", () => {
+        expect(normaliseCid("ipfs://bafy123")).toBe("bafy123");
+    });
+
+    it("passes through a bare CID", () => {
+        expect(normaliseCid("QmFoo")).toBe("QmFoo");
+    });
+});
+
+describe("buildGatewayUrl", () => {
+    const previousGateway = process.env.NEXT_PUBLIC_IPFS_GATEWAY;
+
+    afterEach(() => {
+        if (previousGateway === undefined) {
+            delete process.env.NEXT_PUBLIC_IPFS_GATEWAY;
+        } else {
+            process.env.NEXT_PUBLIC_IPFS_GATEWAY = previousGateway;
+        }
+    });
+
+    it("uses Pinata's gateway by default", () => {
+        delete process.env.NEXT_PUBLIC_IPFS_GATEWAY;
+        expect(buildGatewayUrl("QmFoo")).toBe("https://gateway.pinata.cloud/ipfs/QmFoo");
+    });
+
+    it("honours NEXT_PUBLIC_IPFS_GATEWAY when set", () => {
+        process.env.NEXT_PUBLIC_IPFS_GATEWAY = "https://gw.example";
+        expect(buildGatewayUrl("QmFoo")).toBe("https://gw.example/ipfs/QmFoo");
+    });
+
+    it("trims a trailing slash from the gateway base", () => {
+        process.env.NEXT_PUBLIC_IPFS_GATEWAY = "https://gw.example/";
+        expect(buildGatewayUrl("QmFoo")).toBe("https://gw.example/ipfs/QmFoo");
+    });
+
+    it("accepts an ipfs:// URI as input", () => {
+        process.env.NEXT_PUBLIC_IPFS_GATEWAY = "https://gw.example";
+        expect(buildGatewayUrl("ipfs://QmFoo")).toBe("https://gw.example/ipfs/QmFoo");
+    });
+});
+
+describe("getFallbackGateways", () => {
+    const previousGateway = process.env.NEXT_PUBLIC_IPFS_GATEWAY;
+
+    afterEach(() => {
+        if (previousGateway === undefined) {
+            delete process.env.NEXT_PUBLIC_IPFS_GATEWAY;
+        } else {
+            process.env.NEXT_PUBLIC_IPFS_GATEWAY = previousGateway;
+        }
+    });
+
+    it("returns the primary first, followed by known public gateways", () => {
+        delete process.env.NEXT_PUBLIC_IPFS_GATEWAY;
+        const list = getFallbackGateways();
+        expect(list[0]).toBe("https://gateway.pinata.cloud");
+        expect(list).toContain("https://ipfs.io");
+        expect(list).toContain("https://cloudflare-ipfs.com");
+    });
+
+    it("does not duplicate the primary if it overlaps a fallback", () => {
+        process.env.NEXT_PUBLIC_IPFS_GATEWAY = "https://ipfs.io";
+        const list = getFallbackGateways();
+        const occurrences = list.filter((g) => g === "https://ipfs.io").length;
+        expect(occurrences).toBe(1);
+    });
+});

--- a/frontend/lib/ipfs/__tests__/validation.test.ts
+++ b/frontend/lib/ipfs/__tests__/validation.test.ts
@@ -1,0 +1,71 @@
+import {
+    validateImageUpload,
+    validateEvidenceUpload,
+    IPFS_LIMITS,
+    formatBytes,
+} from "../validation";
+
+function fileOfSize(name: string, type: string, bytes: number): File {
+    return new File([new Uint8Array(bytes)], name, { type });
+}
+
+describe("validateImageUpload", () => {
+    it("accepts a small JPEG", () => {
+        const f = fileOfSize("ok.jpg", "image/jpeg", 1024);
+        expect(validateImageUpload(f)).toEqual({ ok: true });
+    });
+
+    it("accepts PNG, WebP, and GIF", () => {
+        for (const type of ["image/png", "image/webp", "image/gif"]) {
+            expect(validateImageUpload(fileOfSize("x", type, 1024))).toEqual({ ok: true });
+        }
+    });
+
+    it("rejects a PDF", () => {
+        const f = fileOfSize("doc.pdf", "application/pdf", 1024);
+        const result = validateImageUpload(f);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.reason).toMatch(/unsupported type/);
+    });
+
+    it("rejects an empty file", () => {
+        const f = fileOfSize("empty.png", "image/png", 0);
+        const result = validateImageUpload(f);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.reason).toMatch(/empty/);
+    });
+
+    it("rejects a file over the size limit", () => {
+        const tooBig = fileOfSize("big.jpg", "image/jpeg", IPFS_LIMITS.maxFileBytes + 1);
+        const result = validateImageUpload(tooBig);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.reason).toMatch(/larger than/);
+    });
+});
+
+describe("validateEvidenceUpload", () => {
+    it("accepts the same image types plus PDF and MP4", () => {
+        for (const type of [
+            "image/jpeg",
+            "image/png",
+            "video/mp4",
+            "video/webm",
+            "application/pdf",
+        ]) {
+            expect(validateEvidenceUpload(fileOfSize("x", type, 1024))).toEqual({ ok: true });
+        }
+    });
+
+    it("rejects an unknown MIME", () => {
+        const result = validateEvidenceUpload(fileOfSize("x.bin", "application/octet-stream", 1024));
+        expect(result.ok).toBe(false);
+    });
+});
+
+describe("formatBytes", () => {
+    it("formats bytes / KB / MB", () => {
+        expect(formatBytes(512)).toBe("512 B");
+        expect(formatBytes(2048)).toBe("2.0 KB");
+        expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+    });
+});

--- a/frontend/lib/ipfs/gateway.ts
+++ b/frontend/lib/ipfs/gateway.ts
@@ -1,0 +1,53 @@
+/**
+ * IPFS gateway URL construction with a single env-driven base.
+ *
+ * The primary gateway is read from `NEXT_PUBLIC_IPFS_GATEWAY` (so
+ * the same value is available in both browser and server code).
+ * Default: https://gateway.pinata.cloud — the dedicated gateway you
+ * get with a Pinata account.
+ *
+ * `buildGatewayUrl` returns a single URL for the primary gateway.
+ * `getFallbackGateways` returns an ordered list (primary first) so
+ * a caller can implement an `<img onError={fallback}>` chain
+ * without depending on this module.
+ */
+
+const DEFAULT_GATEWAY = "https://gateway.pinata.cloud";
+
+const FALLBACK_GATEWAYS = [
+    "https://ipfs.io",
+    "https://cloudflare-ipfs.com",
+    "https://nftstorage.link",
+] as const;
+
+function getPrimary(): string {
+    const raw =
+        (typeof process !== "undefined"
+            ? process.env.NEXT_PUBLIC_IPFS_GATEWAY
+            : undefined) ?? DEFAULT_GATEWAY;
+    return raw.replace(/\/$/, "");
+}
+
+/**
+ * Build a single gateway URL for the given CID.
+ * Accepts both bare CIDs ("Qm...") and `ipfs://...` URIs.
+ */
+export function buildGatewayUrl(cidOrUri: string): string {
+    const cid = normaliseCid(cidOrUri);
+    return `${getPrimary()}/ipfs/${cid}`;
+}
+
+/**
+ * Ordered list of gateways (primary first, then known public
+ * fallbacks). Each entry is a full base URL — append `/ipfs/<CID>`.
+ */
+export function getFallbackGateways(): string[] {
+    const primary = getPrimary();
+    return [primary, ...FALLBACK_GATEWAYS.filter((g) => g !== primary)];
+}
+
+/** Strip an `ipfs://` prefix if present; otherwise pass through. */
+export function normaliseCid(cidOrUri: string): string {
+    if (cidOrUri.startsWith("ipfs://")) return cidOrUri.slice("ipfs://".length);
+    return cidOrUri;
+}

--- a/frontend/lib/ipfs/pinata.ts
+++ b/frontend/lib/ipfs/pinata.ts
@@ -1,0 +1,125 @@
+/**
+ * Thin server-side wrapper around the Pinata pinning API.
+ *
+ * Reads `PINATA_JWT` from process.env (no `NEXT_PUBLIC_` prefix — the
+ * JWT must stay server-side). All call sites are expected to live in
+ * Next.js Route Handlers under `app/api/ipfs/*`; the browser never
+ * sees the JWT.
+ */
+
+export interface PinataPinResult {
+    cid: string;
+    /** Bytes the file occupied on Pinata (echoed by the API). */
+    pinSize: number;
+    /** ISO timestamp from the Pinata response. */
+    pinnedAt: string;
+}
+
+const PINATA_FILE_ENDPOINT = "https://api.pinata.cloud/pinning/pinFileToIPFS";
+const PINATA_JSON_ENDPOINT = "https://api.pinata.cloud/pinning/pinJSONToIPFS";
+
+function getJwt(): string {
+    const jwt = process.env.PINATA_JWT;
+    if (!jwt) {
+        throw new PinataConfigError(
+            "PINATA_JWT is not set. Add it to your server environment " +
+            "(e.g. .env.local for local dev, Vercel project settings in prod).",
+        );
+    }
+    return jwt;
+}
+
+/**
+ * Pin a file (image, video, document, …) to IPFS via Pinata.
+ *
+ * `name` becomes the Pinata-side label visible in the Pinata dashboard;
+ * it does not affect the CID.
+ */
+export async function pinFile(file: File | Blob, name?: string): Promise<PinataPinResult> {
+    const jwt = getJwt();
+    const form = new FormData();
+    form.append("file", file);
+    if (name) {
+        form.append("pinataMetadata", JSON.stringify({ name }));
+    }
+
+    const res = await fetch(PINATA_FILE_ENDPOINT, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${jwt}` },
+        body: form,
+    });
+
+    if (!res.ok) {
+        const body = await safeText(res);
+        throw new PinataUploadError(
+            `Pinata pinFileToIPFS failed (${res.status}): ${body}`,
+            res.status,
+        );
+    }
+
+    const data = (await res.json()) as {
+        IpfsHash: string;
+        PinSize: number;
+        Timestamp: string;
+    };
+    return { cid: data.IpfsHash, pinSize: data.PinSize, pinnedAt: data.Timestamp };
+}
+
+/**
+ * Pin a JSON object as IPFS metadata. Useful for spot descriptions,
+ * dispute evidence metadata, and similar small structured payloads.
+ */
+export async function pinJson(json: unknown, name?: string): Promise<PinataPinResult> {
+    const jwt = getJwt();
+
+    const res = await fetch(PINATA_JSON_ENDPOINT, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${jwt}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            pinataContent: json,
+            ...(name ? { pinataMetadata: { name } } : {}),
+        }),
+    });
+
+    if (!res.ok) {
+        const body = await safeText(res);
+        throw new PinataUploadError(
+            `Pinata pinJSONToIPFS failed (${res.status}): ${body}`,
+            res.status,
+        );
+    }
+
+    const data = (await res.json()) as {
+        IpfsHash: string;
+        PinSize: number;
+        Timestamp: string;
+    };
+    return { cid: data.IpfsHash, pinSize: data.PinSize, pinnedAt: data.Timestamp };
+}
+
+async function safeText(res: Response): Promise<string> {
+    try {
+        return await res.text();
+    } catch {
+        return "<no body>";
+    }
+}
+
+export class PinataConfigError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "PinataConfigError";
+    }
+}
+
+export class PinataUploadError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+        super(message);
+        this.name = "PinataUploadError";
+        this.status = status;
+    }
+}

--- a/frontend/lib/ipfs/validation.ts
+++ b/frontend/lib/ipfs/validation.ts
@@ -1,0 +1,69 @@
+/**
+ * File validation rules shared between the client (pre-upload UI
+ * feedback) and the server (route handler hard limits).
+ *
+ * The two sides must use the same numbers so a file that passes the
+ * picker isn't rejected by the API.
+ */
+
+export const IPFS_LIMITS = {
+    /** Hard cap on a single file upload, in bytes. */
+    maxFileBytes: 10 * 1024 * 1024, // 10 MB
+} as const;
+
+export const ALLOWED_IMAGE_MIME = new Set<string>([
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+]);
+
+export const ALLOWED_EVIDENCE_MIME = new Set<string>([
+    ...ALLOWED_IMAGE_MIME,
+    "video/mp4",
+    "video/webm",
+    "application/pdf",
+]);
+
+export type ValidationResult =
+    | { ok: true }
+    | { ok: false; reason: string };
+
+export function validateImageUpload(file: File | Blob, fileName?: string): ValidationResult {
+    return validateAgainst(file, ALLOWED_IMAGE_MIME, fileName);
+}
+
+export function validateEvidenceUpload(file: File | Blob, fileName?: string): ValidationResult {
+    return validateAgainst(file, ALLOWED_EVIDENCE_MIME, fileName);
+}
+
+function validateAgainst(
+    file: File | Blob,
+    allowedTypes: Set<string>,
+    fileName?: string,
+): ValidationResult {
+    const name = fileName ?? ("name" in file ? (file as File).name : "file");
+
+    if (file.size <= 0) {
+        return { ok: false, reason: `${name} is empty` };
+    }
+    if (file.size > IPFS_LIMITS.maxFileBytes) {
+        return {
+            ok: false,
+            reason: `${name} is ${formatBytes(file.size)}, larger than the ${formatBytes(IPFS_LIMITS.maxFileBytes)} limit`,
+        };
+    }
+    if (!allowedTypes.has(file.type)) {
+        return {
+            ok: false,
+            reason: `${name} has unsupported type "${file.type || "unknown"}"`,
+        };
+    }
+    return { ok: true };
+}
+
+export function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/frontend/lib/utils/evidenceHandler.ts
+++ b/frontend/lib/utils/evidenceHandler.ts
@@ -3,6 +3,10 @@
  * Utilities for handling dispute evidence submission, IPFS uploads, and validation
  */
 
+import { uploadToIPFS } from "@/lib/ipfs";
+import { buildGatewayUrl } from "@/lib/ipfs/gateway";
+import { validateEvidenceUpload } from "@/lib/ipfs/validation";
+
 export enum EvidenceType {
   CheckInTimestamp = 0,
   CheckOutTimestamp = 1,
@@ -32,35 +36,22 @@ export interface DisputeEvidence {
 }
 
 /**
- * Convert file to IPFS hash
- * This is a placeholder - actual implementation would upload to IPFS
+ * Upload dispute evidence to IPFS. Returns the CID (Pinata
+ * pinFileToIPFS hash). Accepts File (preferred — preserves the
+ * filename for the Pinata-side label) or a bare Blob.
+ *
+ * The `type` parameter is preserved on the caller side; the
+ * evidence-type → on-chain hash association happens when the CID is
+ * submitted via dispute-resolution.add-evidence.
  */
 export async function uploadEvidenceToIPFS(
   file: File | Blob,
-  type: EvidenceType
+  _type: EvidenceType
 ): Promise<string> {
-  // TODO: Implement actual IPFS upload
-  // For now, return a mock hash
-  const formData = new FormData();
-  formData.append('file', file);
-
-  try {
-    // Example using Pinata or other IPFS service
-    const response = await fetch('/api/ipfs/upload', {
-      method: 'POST',
-      body: formData
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to upload to IPFS');
-    }
-
-    const data = await response.json();
-    return data.hash;
-  } catch (error) {
-    console.error('IPFS upload error:', error);
-    throw error;
-  }
+  const named =
+    file instanceof File ? file : new File([file], "evidence", { type: file.type });
+  const { hash } = await uploadToIPFS(named);
+  return hash;
 }
 
 /**
@@ -73,15 +64,19 @@ export function ipfsHashToBytes(hash: string): string {
 }
 
 /**
- * Get IPFS gateway URL from hash
+ * Get IPFS gateway URL from a CID. Delegates to the shared gateway
+ * module so the choice of primary gateway lives in one place
+ * (NEXT_PUBLIC_IPFS_GATEWAY).
  */
 export function getIPFSGatewayURL(hash: string): string {
-  const gateway = process.env.NEXT_PUBLIC_IPFS_GATEWAY || 'https://ipfs.io/ipfs/';
-  return `${gateway}${hash}`;
+  return buildGatewayUrl(hash);
 }
 
 /**
- * Validate evidence before submission
+ * Validate evidence before submission. Delegates the file-level
+ * checks (size, MIME type) to the shared validateEvidenceUpload
+ * so that the picker UI, this helper, and the /api/ipfs/upload
+ * route are all enforcing the same rules.
  */
 export function validateEvidence(
   type: EvidenceType,
@@ -89,38 +84,20 @@ export function validateEvidence(
   description?: string
 ): { valid: boolean; error?: string } {
   if (!description || description.trim().length === 0) {
-    return { valid: false, error: 'Evidence description is required' };
+    return { valid: false, error: "Evidence description is required" };
   }
 
-  if (type === EvidenceType.Image || type === EvidenceType.Video || type === EvidenceType.Document) {
-    if (!file) {
-      return { valid: false, error: 'File is required for this evidence type' };
-    }
-
-    // Validate file size (max 10MB)
-    const maxSize = 10 * 1024 * 1024;
-    if (file.size > maxSize) {
-      return { valid: false, error: 'File size exceeds 10MB limit' };
-    }
-
-    // Validate image types
-    if (type === EvidenceType.Image && file.type.startsWith('image/')) {
-      const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-      if (!allowedTypes.includes(file.type)) {
-        return { valid: false, error: 'Invalid image format. Allowed: JPEG, PNG, WebP, GIF' };
-      }
-    }
-
-    // Validate video types
-    if (type === EvidenceType.Video && file.type.startsWith('video/')) {
-      const allowedTypes = ['video/mp4', 'video/webm', 'video/quicktime'];
-      if (!allowedTypes.includes(file.type)) {
-        return { valid: false, error: 'Invalid video format. Allowed: MP4, WebM, QuickTime' };
-      }
-    }
+  const requiresFile =
+    type === EvidenceType.Image ||
+    type === EvidenceType.Video ||
+    type === EvidenceType.Document;
+  if (requiresFile && !file) {
+    return { valid: false, error: "File is required for this evidence type" };
   }
+  if (!file) return { valid: true };
 
-  return { valid: true };
+  const result = validateEvidenceUpload(file);
+  return result.ok ? { valid: true } : { valid: false, error: result.reason };
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the mock IPFS layer (which returned random \`Qm…\` hashes after a \`setTimeout\`) with a real Pinata-backed pipeline. The browser uploads via two new Route Handlers under \`app/api/ipfs/\`, which hold the Pinata JWT server-side — \`PINATA_JWT\` is intentionally not \`NEXT_PUBLIC_\`.

10 commits:

| # | Commit |
|---|---|
| 1 | \`feat(ipfs)\`: server-side Pinata client wrapper (\`pinFile\`, \`pinJson\`) |
| 2 | \`feat(ipfs)\`: shared file validation (\`validateImageUpload\`, \`validateEvidenceUpload\`, \`IPFS_LIMITS\`) |
| 3 | \`feat(ipfs)\`: wire \`/api/ipfs/upload\` to Pinata |
| 4 | \`feat(ipfs)\`: add \`/api/ipfs/upload-json\` route for metadata pins |
| 5 | \`feat(ipfs)\`: rewrite \`lib/ipfs.ts\` to call the project's API routes |
| 6 | \`feat(ipfs)\`: extract gateway URL helpers into \`lib/ipfs/gateway.ts\` |
| 7 | \`feat(ipfs)\`: wire \`ImageUpload\` component to real Pinata upload |
| 8 | \`feat(ipfs)\`: route \`evidenceHandler\` through the shared IPFS module |
| 9 | \`test(ipfs)\`: jest coverage for validation and gateway helpers (16 tests) |
| 10 | \`docs(ipfs)\`: rewrite \`.env.example\` and add \`lib/ipfs/README.md\` |

## Why an API route instead of calling Pinata from the browser?

The Pinata JWT is a bearer token for the entire account. If shipped to the browser via \`NEXT_PUBLIC_PINATA_JWT\` (as the old \`.env.example\` did), every visitor could pin arbitrary data and burn the storage quota. The Route Handlers proxy the upload so the credential stays server-side. \`lib/ipfs/README.md\` documents this so a future contributor doesn't undo it for convenience.

## Configuration

| Env var | Where read | Required |
|---|---|---|
| \`PINATA_JWT\` | server only | yes, for uploads |
| \`NEXT_PUBLIC_IPFS_GATEWAY\` | browser + server | no — default \`https://gateway.pinata.cloud\` |

Get a JWT from Pinata → API Keys → "New JWT".

## What's covered

- File pin (\`pinFileToIPFS\`) and JSON pin (\`pinJSONToIPFS\`)
- Image-only validation (\`uploadImageToIPFS\`) and evidence validation (image + video + PDF)
- Pre-validation in \`ImageUpload\` so users see "PDF not supported" before the round-trip
- Gateway URL helper that honours \`NEXT_PUBLIC_IPFS_GATEWAY\` and trims trailing slashes
- Fallback gateway list (Pinata, ipfs.io, Cloudflare, NFT.Storage) for an \`<img onError>\` chain
- 16 jest tests covering validation and gateway, all passing on this branch

## Cannot end-to-end test without a Pinata account

Without a real \`PINATA_JWT\`, the API routes return 500 with \`"PINATA_JWT is not set"\` — that's intentional. To verify end-to-end: set \`PINATA_JWT\` to a real value in \`.env.local\`, then upload a spot photo from the owner dashboard.

## Test plan

- [ ] \`cd frontend && npm ci && npx tsc --noEmit\` passes
- [ ] \`cd frontend && npm test\` → 16/16 jest tests pass
- [ ] Set \`PINATA_JWT\` locally, upload a JPEG ≤ 10 MB → response contains a real CID, content resolves via gateway
- [ ] Upload a PDF → rejected in-browser with "PDFs not supported" (no network round-trip)
- [ ] Upload a 12 MB image → rejected with size message
- [ ] Without \`PINATA_JWT\` set: API returns 500 with the config-error message (not a generic 502)

## Remaining IPFS TODOs (out of scope)

- \`components/owner/MapPicker.tsx\` — geocoding TODO unrelated to IPFS
- Embedding the spot-photo CID into the parking-spot Clarity record is a contract change, follow-up
- Wiring the IPFS module into the dispute submission flow (file evidence + JSON metadata) — uses the helpers from this PR, follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)